### PR TITLE
fix(comms): stop detached daemon inheriting launcher std handles on windows

### DIFF
--- a/src/comms/singleton.rs
+++ b/src/comms/singleton.rs
@@ -530,9 +530,60 @@ pub fn spawn_detached_daemon(_paths: &CommsPaths) -> std::io::Result<()> {
         /// `CreateProcess` flag: do not allocate a console window for the child.
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+        // Stop the long-lived daemon from inheriting our standard handles. `CreateProcess` is
+        // called with `bInheritHandles = TRUE` whenever stdio is redirected (it is, to NUL above),
+        // and that inherits EVERY inheritable handle in this process — including the stdout/stderr
+        // pipe a parent gave us when it captured our output (e.g. `Command::output()`, or `serve`'s
+        // MCP stdio). The detached daemon would then hold the write end open forever, so the
+        // capturing parent never sees EOF and blocks until the daemon dies — the Windows-only
+        // `comms start` hang. Unix avoids this because `Stdio::null()` dup2's /dev/null over the
+        // child fds and Rust sets CLOEXEC on its own pipes. Clearing the inherit bit on our std
+        // handles first makes the detached spawn leak none of them.
+        clear_std_handle_inheritance();
     }
     command.spawn()?;
     Ok(())
+}
+
+/// Clear `HANDLE_FLAG_INHERIT` on this process's standard input/output/error handles so a
+/// subsequently spawned child does not inherit them. See the call site in [`spawn_detached_daemon`]
+/// for why the detached daemon must not inherit a captured stdout/stderr pipe. Clearing the inherit
+/// bit does not affect this process's own use of the handles — only whether children receive a
+/// duplicate — so it is safe for the short-lived `comms start` CLI and for `serve` (whose later
+/// child spawns pass their stdio explicitly rather than relying on inheritance).
+#[cfg(windows)]
+fn clear_std_handle_inheritance() {
+    /// `GetStdHandle` selectors (Win32 `STD_*_HANDLE`, defined as negative `DWORD`s).
+    const STD_INPUT_HANDLE: u32 = -10i32 as u32;
+    const STD_OUTPUT_HANDLE: u32 = -11i32 as u32;
+    const STD_ERROR_HANDLE: u32 = -12i32 as u32;
+    /// `SetHandleInformation` mask bit controlling handle inheritance.
+    const HANDLE_FLAG_INHERIT: u32 = 0x0000_0001;
+    /// `GetStdHandle` failure sentinel.
+    const INVALID_HANDLE_VALUE: isize = -1;
+
+    for selector in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        // SAFETY: both calls take only primitive arguments and read no caller memory.
+        // `GetStdHandle` returns the process's current standard handle (or null /
+        // `INVALID_HANDLE_VALUE`, which we skip); `SetHandleInformation` only clears the inherit
+        // bit on that handle. Neither touches our heap or thread state, so the calls are safe.
+        unsafe {
+            let handle = GetStdHandle(selector);
+            if handle != 0 && handle != INVALID_HANDLE_VALUE {
+                let _ = SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    /// Win32 `GetStdHandle` — returns the handle for a standard device (`STD_*_HANDLE`).
+    fn GetStdHandle(nstdhandle: u32) -> isize;
+    /// Win32 `SetHandleInformation` — sets the masked flag bits on a handle. Returns nonzero on
+    /// success.
+    fn SetHandleInformation(hobject: isize, dwmask: u32, dwflags: u32) -> i32;
 }
 
 #[cfg(unix)]

--- a/tests/comms_cli_smoke.rs
+++ b/tests/comms_cli_smoke.rs
@@ -8,13 +8,14 @@
 //! It also pins the **condensation** contract end to end: `comms history --json` for a different
 //! agent returns the message front-matter (subject) but NEVER the body bytes.
 //!
-//! Unix-only: the `comms start` detached-daemon spawn + readiness handshake deadlocks on Windows
-//! (every test in this file hung to the CI timeout even after the per-`comms_dir` named-pipe
-//! isolation fix, so the deadlock is in the detach/readiness path, not the pipe name). The
-//! in-process + direct-daemon-spawn suites in `comms_smoke.rs` run on Windows and cover the broker.
-//! Tracked in #110.
+//! Runs on Unix and Windows. `comms start` previously hung forever on Windows: the detached daemon
+//! inherited the launcher's stdout/stderr (Windows `CreateProcess` with `bInheritHandles = TRUE`
+//! leaks every inheritable handle, including the pipe `Command::output()` captures), so the capturing
+//! parent never saw EOF and blocked until the daemon died. `spawn_detached_daemon` now clears the
+//! inherit bit on its std handles before the detached spawn, so the daemon leaks none of them. The
+//! in-process + direct-daemon-spawn suites in `comms_smoke.rs` cover the broker itself.
 
-#![cfg(all(feature = "comms", unix))]
+#![cfg(feature = "comms")]
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
## What

`comms start` hung forever on Windows. The detached broker daemon inherited the launcher's stdout/stderr: Windows `CreateProcess` runs with `bInheritHandles = TRUE` whenever stdio is redirected (it is, to NUL), so every inheritable handle leaks into the child — including the stdout/stderr pipe a parent handed us when capturing output (`Command::output()`, or `serve`'s MCP stdio). The long-lived daemon held the write end open, so the capturing parent never saw EOF and blocked until the daemon died.

Unix is unaffected: `Stdio::null` dup2's `/dev/null` over the child fds and Rust sets `CLOEXEC` on its own pipe fds — hence the Windows-only symptom.

## Fix

Clear `HANDLE_FLAG_INHERIT` on the launcher's std handles (via `GetStdHandle` + `SetHandleInformation`, externed from kernel32 like the existing `setsid`) before the detached spawn, so the daemon inherits none of them. Re-enable `comms_cli_smoke` on Windows.

## Validation

- Unix: `comms_cli_smoke` (3) + `comms_smoke` (6) green; full prek triad clean.
- Windows compile + link verified via mingw cross-build (`x86_64-pc-windows-gnu`).
- This PR's `windows-latest / comms shells` leg is the real-Windows gate for the un-gated `comms_cli_smoke`.

Closes #112 (internal).