### PR TITLE
Harden plugin install against partial releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -257,7 +257,14 @@ jobs:
             case "$tag" in
               *-rc.* | *-beta* | *-alpha*) prerelease="--prerelease" ;;
             esac
-            gh release create "$tag" --title "$tag" --notes "Release $tag" --verify-tag $prerelease
+            # Create as a DRAFT. The build matrix uploads binaries to it, but it
+            # stays invisible (assets not publicly downloadable) until the
+            # finalize_release job promotes it — and that job only runs once
+            # checksums (which requires all 4 platform binaries) succeeds. A failed
+            # platform build therefore leaves a hidden draft, not a live release
+            # with missing binaries and no checksums (the v0.10.0 failure mode that
+            # broke the plugin launcher's checksum-verified download).
+            gh release create "$tag" --title "$tag" --notes "Release $tag" --verify-tag --draft $prerelease
           fi
 
   # macOS + Windows binaries. Linux binaries are built separately in
@@ -566,6 +573,53 @@ jobs:
           gh release upload "$tag" basemind_${{ needs.meta.outputs.version }}_checksums.txt --clobber
           echo "✓ Uploaded checksums to release"
 
+  finalize_release:
+    name: Publish GitHub release
+    needs: [meta, checksums]
+    # Run after the build/checksums jobs settle, regardless of their result, so a
+    # draft left complete by a cancelled/partial earlier run can still be promoted.
+    # The step re-verifies completeness itself, so it never publishes an incomplete
+    # release — it only flips the draft to live once ALL 4 platform archives AND the
+    # checksums file are present. This is the gate that makes a partial publish a
+    # hidden draft instead of a live, half-populated release.
+    if: always() && needs.meta.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote draft to a published release once complete
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.meta.outputs.tag }}"
+          version="${{ needs.meta.outputs.version }}"
+
+          # The full asset set a launcher / npm install.js / pip downloader needs:
+          # every platform archive plus the checksums file they verify against.
+          required=(
+            "basemind-x86_64-unknown-linux-gnu.tar.gz"
+            "basemind-aarch64-unknown-linux-gnu.tar.gz"
+            "basemind-aarch64-apple-darwin.tar.gz"
+            "basemind-x86_64-pc-windows-msvc.zip"
+            "basemind_${version}_checksums.txt"
+          )
+
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name' \
+            > /tmp/assets.txt || true
+          missing=0
+          for asset in "${required[@]}"; do
+            if ! grep -qx "$asset" /tmp/assets.txt; then
+              echo "::error::release $tag is missing $asset"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::release $tag is incomplete ($missing required assets missing); leaving it as a draft"
+            exit 1
+          fi
+
+          gh release edit "$tag" --draft=false --repo "$GITHUB_REPOSITORY"
+          echo "✓ Promoted $tag to a published release"
+
   publish_crates:
     name: Publish crates.io
     needs: meta
@@ -604,8 +658,10 @@ jobs:
 
   publish_npm:
     name: Publish npm
-    needs: [meta, checksums]
-    if: needs.meta.outputs.npm_exists != 'true' && needs.checksums.result == 'success'
+    # Gated on finalize_release: the npm install.js downloads the platform binary
+    # from the GitHub release, so it must not publish until that release is live.
+    needs: [meta, finalize_release]
+    if: needs.meta.outputs.npm_exists != 'true' && needs.finalize_release.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -640,8 +696,8 @@ jobs:
 
   publish_opencode:
     name: Publish npm (basemind-opencode)
-    needs: [meta, checksums]
-    if: needs.meta.outputs.opencode_exists != 'true' && needs.checksums.result == 'success'
+    needs: [meta, finalize_release]
+    if: needs.meta.outputs.opencode_exists != 'true' && needs.finalize_release.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -676,8 +732,10 @@ jobs:
 
   publish_pypi:
     name: Publish PyPI
-    needs: [meta, checksums]
-    if: needs.meta.outputs.pypi_exists != 'true' && needs.checksums.result == 'success'
+    # Gated on finalize_release: the pip downloader fetches the platform binary
+    # from the GitHub release, so it must not publish until that release is live.
+    needs: [meta, finalize_release]
+    if: needs.meta.outputs.pypi_exists != 'true' && needs.finalize_release.result == 'success'
     runs-on: ubuntu-latest
     environment: pypi
     steps:
@@ -708,9 +766,10 @@ jobs:
   publish_homebrew:
     name: Update Homebrew formula
     # Stable releases only — rc/beta/alpha pre-releases do not update the tap.
-    # Requires checksums job to succeed (which ensures all 4 binaries exist).
-    needs: [meta, checksums]
-    if: needs.checksums.result == 'success' && !contains(needs.meta.outputs.version, '-rc') && !contains(needs.meta.outputs.version, '-beta') && !contains(needs.meta.outputs.version, '-alpha')
+    # Requires the release to be finalized (all 4 binaries + checksums present and
+    # the release published), since the formula points at the release assets.
+    needs: [meta, finalize_release]
+    if: needs.finalize_release.result == 'success' && !contains(needs.meta.outputs.version, '-rc') && !contains(needs.meta.outputs.version, '-beta') && !contains(needs.meta.outputs.version, '-alpha')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/mcp-launch.sh
+++ b/scripts/mcp-launch.sh
@@ -35,6 +35,14 @@ die() {
   exit 1
 }
 
+# A failed asset or checksums fetch almost always means the pinned release is
+# INCOMPLETE — some platform binaries or the checksums file never finished
+# publishing (a partial release). Surface that as an actionable instruction
+# instead of a bare error the MCP client renders as an opaque "failed to connect".
+die_incomplete_release() {
+  die "$1 — the basemind v${VERSION} release looks incomplete (a missing platform asset or checksums file). Update the basemind plugin to a complete release (Claude Code: run \`/plugin update\`); if it persists, report it at https://github.com/Goldziher/basemind/issues"
+}
+
 # Resolve the plugin root: prefer the value Claude Code injects, else derive it
 # from this script's location (scripts/ lives one level under the plugin root).
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
@@ -167,16 +175,17 @@ try_exec "$MANAGED_BIN" "$@"
 
 TMP="$(mktemp -d)"
 log "downloading $ASSET ..."
-fetch "$ASSET_URL" "$TMP/$ASSET" || die "download failed: $ASSET_URL"
+fetch "$ASSET_URL" "$TMP/$ASSET" || die_incomplete_release "could not download $ASSET ($ASSET_URL)"
 
 # Fail CLOSED: the checksums file MUST be fetchable and MUST contain an entry for
 # this asset. A missing file or absent entry aborts rather than installing an
-# unverified binary.
+# unverified binary — and almost always means the release published without its
+# checksums (the v0.10.0 partial-publish failure mode), so point at the fix.
 fetch "$SUMS_URL" "$TMP/checksums.txt" ||
-  die "could not fetch checksums ($SUMS_URL) — refusing to install unverified binary"
+  die_incomplete_release "could not fetch checksums ($SUMS_URL); refusing to install an unverified binary"
 EXPECTED="$(awk -v f="$ASSET" '{name=$NF; sub(/^[*]/, "", name); if (name == f) print $1}' "$TMP/checksums.txt")"
 [ -n "$EXPECTED" ] ||
-  die "no checksum entry for $ASSET in $SUMS_URL — refusing to install unverified binary"
+  die_incomplete_release "no checksum entry for $ASSET in $SUMS_URL; refusing to install an unverified binary"
 ACTUAL="$(sha256 "$TMP/$ASSET")"
 [ -n "$ACTUAL" ] || die "failed to compute sha256 for $ASSET"
 [ "$EXPECTED" = "$ACTUAL" ] || die "checksum mismatch for $ASSET (expected $EXPECTED, got $ACTUAL)"


### PR DESCRIPTION
## Why

v0.10.0 was a partial publish: only its macOS + Windows binaries uploaded (the Linux build legs failed), so the `checksums` job was skipped — but `create_release` had already made the GitHub release **live**, leaving it half-populated with no checksums file. The plugin launcher (`mcp-launch.sh`) verifies the download against the release checksums and **fails closed** when they're absent, so **every user pinned to plugin v0.10.0 got a dead MCP server** that surfaced only as an opaque "failed to connect".

New installs are already safe (marketplace/plugin.json = 0.10.2, a complete release). This makes the failure mode impossible going forward and legible when it does occur.

## What

**1. Launcher (`scripts/mcp-launch.sh`)** — a `die_incomplete_release` helper. The three publish-gap failures (asset download, checksums fetch, missing checksum entry) now name the cause and tell the user to update the plugin (`/plugin update`) instead of dying with a bare message the client renders as "failed to connect".

**2. Publish workflow (`.github/workflows/publish.yaml`)** — release atomicity:
- `create_release` now creates the GitHub release as a **draft**.
- New `finalize_release` job flips it to a published release **only once all 4 platform archives + the checksums file are present**. It self-verifies the asset set, so a complete-but-draft release left by a cancelled run is recoverable on re-run.
- `publish_npm` / `publish_opencode` / `publish_pypi` / `publish_homebrew` now gate on `finalize_release` (they download binaries from the release, so must not ship until it's live).

Net: a failed platform build leaves a **hidden draft**, never a live release with missing binaries/checksums.

## Validation
- `mcp-launch.sh`: shellcheck + shfmt clean, `bash -n` ok.
- `publish.yaml`: valid YAML; walked the happy-path, partial-build-failure, cancelled-rerun, and rc/prerelease paths.
- **Cannot be exercised locally** — the publish workflow is tag-triggered against real registries. It needs your review and will be validated on the next real release (a draft that promotes itself on success).

## Not covered here (your call)
- Rescuing the stranded v0.10.0 cohort: I did not touch the v0.10.0 release. Options are (a) upload a `basemind_0.10.0_checksums.txt` for its 2 existing macOS/Windows assets to revive those users, (b) delete the broken release, or (c) leave it and rely on `/plugin update`. Can't safely backfill its Linux binaries (that tag has the rpath bug fixed in 0.10.2).
- Coarse re-run idempotency (a failed *build* leg isn't rebuilt on re-run because assets already exist) is pre-existing and unchanged.