### PR TITLE
fix(statusline): make file mtime reads portable on GNU/Linux

### DIFF
--- a/.claude-plugin/statusline.sh
+++ b/.claude-plugin/statusline.sh
@@ -36,6 +36,15 @@ json() { # json <jq-filter> <default>
   [[ -n "$out" ]] && printf '%s' "$out" || printf '%s' "$2"
 }
 
+epoch_mtime() { # epoch_mtime <path> → file mtime in seconds since epoch, or 0
+  # GNU coreutils first, then BSD/macOS. Order matters: GNU `stat -f` means
+  # "filesystem status" (and SUCCEEDS with unrelated output), so probing
+  # `-f %m` first on Linux returns a multi-line "File: …" blob that then trips
+  # `set -u` in the arithmetic compares below. Try `-c %Y` (GNU) first so the
+  # `-f %m` (BSD) branch is only reached where `-c` genuinely fails.
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
 cwd="$(json '.workspace.current_dir // .cwd' "${PWD}")"
 model="$(json '.model.display_name' '')"
 out_style="$(json '.output_style.name' '')"
@@ -186,7 +195,7 @@ build_basemind_line() {
   local scan_age="never" scan_delta=999999999 scan_mtime=0 m now
   for candidate in "${bm_dir}/views/working/index.msgpack" "${bm_dir}/views/working/index.fjall"; do
     if [[ -e "$candidate" ]]; then
-      m="$(stat -f %m "$candidate" 2>/dev/null || stat -c %Y "$candidate" 2>/dev/null || echo 0)"
+      m="$(epoch_mtime "$candidate")"
       [[ "$m" -gt "$scan_mtime" ]] && scan_mtime="$m"
     fi
   done
@@ -206,7 +215,7 @@ build_basemind_line() {
   local calls=0 saved=0 code=0 git=0 docs=0 mem=0 web=0 tel_mtime=0
   local tel_file="${bm_dir}/telemetry.jsonl"
   if [[ -f "$tel_file" ]]; then
-    tel_mtime="$(stat -f %m "$tel_file" 2>/dev/null || stat -c %Y "$tel_file" 2>/dev/null || echo 0)"
+    tel_mtime="$(epoch_mtime "$tel_file")"
     if [[ $have_jq -eq 1 ]]; then
       local midnight_us
       midnight_us="$(date -v0H -v0M -v0S +%s 2>/dev/null || date -d 'today 00:00' +%s 2>/dev/null || echo 0)"


### PR DESCRIPTION
## Problem

The status line renders blank on every Linux host. `build_basemind_line` reads file mtimes with:

```sh
m="$(stat -f %m "$candidate" 2>/dev/null || stat -c %Y "$candidate" 2>/dev/null || echo 0)"
```

`stat -f %m` is BSD/macOS syntax. On GNU coreutils, `-f` means **"display filesystem status"** — and it *succeeds*, printing a multi-line blob instead of failing:

```
  File: "/…/.basemind/views/working/index.fjall"
    ID: 9ad96abec60b0f91 Namelen: 255     Type: ext2/ext3
...
```

Because that first command exits `0`, the `|| stat -c %Y` fallback never runs. The blob then reaches the arithmetic compare `[[ "$m" -gt "$scan_mtime" ]]`, where `set -euo pipefail` aborts on the bare word `File` as an unbound variable:

```
statusline.sh: line 190: File: unbound variable
```

The whole line is produced in a command substitution, so the error empties it — basemind's status line silently disappears on Linux.

## Fix

Extract an `epoch_mtime` helper that tries GNU `stat -c %Y` **first**, falling back to BSD `stat -f %m` only when `-c` genuinely fails (as it does on macOS). Used at both call sites (scan-recency and telemetry mtime).

## Verification

`tests/statusline_smoke.sh` **reproduced the failure** before this change (`line 190: File: unbound variable`, non-zero exit) and **passes** after, on Linux:

```
  ok  exit 0
  ok  ANSI escape present
  ok  true-color brand orange #F97316 present
  ok  brand glyph ◆ present
  ok  name present
  ok  liveness dot present
  ok  file count 7 from blob fixture
  ok  legacy .l1/.l2 index renders ready with 4 files (no double-count)
  ok  unscanned (no blobs) renders scanning hint
  ok  missing .basemind/ shows actionable hint
statusline_smoke: all checks passed
```

The BSD fallback preserves existing macOS behavior.