### PR TITLE
Hardening: resource stats, git precision, CLI↔MCP parity, lock/latency UX

### DIFF
--- a/.claude-plugin/statusline.sh
+++ b/.claude-plugin/statusline.sh
@@ -95,6 +95,20 @@ fmt_thousands() {
   local n="$1"
   LC_ALL=en_US.UTF-8 printf "%'d" "$n" 2>/dev/null || printf '%d' "$n"
 }
+# Kilobytes → human size (matches `du -h` / the MCP cache_stats units): 900 → 900K,
+# 15360 → 15M, 1572864 → 1.5G. Input is KB (what `du -sk` and `ps -o rss=` report).
+fmt_kb() {
+  local kb="$1"
+  [[ -z "$kb" || "$kb" -le 0 ]] 2>/dev/null && {
+    printf '0'
+    return
+  }
+  if [[ "$kb" -lt 1024 ]]; then
+    printf '%dK' "$kb"
+  elif [[ "$kb" -lt 1048576 ]]; then
+    printf '%dM' "$((kb / 1024))"
+  else printf '%d.%dG' "$((kb / 1048576))" "$(((kb * 10 / 1048576) % 10))"; fi
+}
 
 # Agent-comms state — prints "<unread> <agent>" or nothing. Cheap and side-effect-free:
 #   * only runs when a comms-capable `basemind` is on PATH (the cargo `--features comms`
@@ -298,6 +312,27 @@ build_basemind_line() {
 
   out+="  ${sep}│${reset}  "
   out+="${bold}${magenta}$(fmt_count "$saved")${reset} ${label}saved${reset}"
+
+  # Resource footprint (full tier only): on-disk `.basemind/` size + live serve-process RSS. Both
+  # are cheap best-effort probes — `du -sk` on the cache dir and `ps` on the serve pid — and are
+  # simply omitted if the tools/values aren't available. Mirrors the MCP/CLI cache_stats surface.
+  if [[ "$tier" == "full" ]]; then
+    local disk_kb="" rss_kb="" res_seg=""
+    res_add() {
+      [[ -n "$res_seg" ]] && res_seg+=" ${sep}·${reset} "
+      res_seg+="$1"
+    }
+    disk_kb="$(du -sk "$bm_dir" 2>/dev/null | awk '{print $1}')"
+    [[ -n "$disk_kb" ]] && res_add "${bold}${cyan}$(fmt_kb "$disk_kb")${reset} ${label}disk${reset}"
+    if [[ $serve_running -eq 1 ]] && command -v ps >/dev/null 2>&1; then
+      local serve_pid
+      serve_pid="$(pgrep -f "basemind serve" 2>/dev/null | head -1)"
+      [[ -n "$serve_pid" ]] && rss_kb="$(ps -o rss= -p "$serve_pid" 2>/dev/null | tr -d ' ')"
+      [[ -n "$rss_kb" && "$rss_kb" -gt 0 ]] 2>/dev/null &&
+        res_add "${bold}${cyan}$(fmt_kb "$rss_kb")${reset} ${label}rss${reset}"
+    fi
+    [[ -n "$res_seg" ]] && out+="  ${sep}│${reset}  $res_seg"
+  fi
 
   # Comms segment: unread (bright when >0, dim at zero) + identity in the full tier.
   if [[ -n "$comms_unread" ]]; then

--- a/.codex-plugin/commands/bm-stats.md
+++ b/.codex-plugin/commands/bm-stats.md
@@ -1,16 +1,33 @@
 ---
 name: bm-stats
-description: Show basemind activity dashboard — tool calls, per-tool histogram, estimated tokens saved.
+description: basemind dashboard — resource footprint (disk + RAM) and activity (tool calls, per-tool histogram, estimated tokens saved). Works with or without the MCP server.
 ---
 
-# bm-stats — basemind activity dashboard
+# bm-stats — basemind dashboard
 
-Call the basemind MCP tool `telemetry_summary` and render the result as a
-markdown dashboard.
+Show a basemind dashboard with two sections: **resource footprint** (on-disk size + process RAM) and
+**activity** (tool calls, per-tool histogram, estimated tokens saved). $ARGUMENTS
 
-Default window is `today`. If the user asks for a specific range, map it to one
-of `today`, `1h`, `24h`, `all`.
+Prefer the MCP tools when they're connected, but do **not** depend on them — the CLI reads the same
+data with no server (the MCP server can be reconnecting, or not running at all). If a step's MCP tool
+isn't available, run its CLI equivalent instead of giving up.
 
-Always end with a one-sentence disclosure that the savings number is heuristic:
-tools without a realistic baseline (memory, document search, git wrappers)
-report 0 saved.
+Default window is `today`. If the user asks for a range, map it to one of `today`, `1h`, `24h`, `all`.
+
+1. **Resource footprint.** MCP tool `cache_stats`, or CLI `basemind cache stats` (add `--json` to
+   parse). Report: `total_bytes` (matches `du`), the per-component breakdown (blobs / views /
+   git-history / lance / git-cache / telemetry / other), and process RAM (`rss_bytes` +
+   `peak_rss_bytes`). If `blob_accounting_ok` is `false`, note that orphan accounting was skipped
+   (stale/unreadable index — re-scan to restore it); the sizes are still accurate.
+
+2. **Activity.** MCP tool `telemetry_summary`, or CLI `basemind telemetry --window <today|1h|24h|all>`
+   (add `--json`). Report call count, the per-tool histogram, and estimated tokens saved for the
+   window.
+
+3. **Render** both sections as a compact markdown dashboard.
+
+If neither MCP nor CLI is reachable (no `basemind` binary and no server), say so plainly and point at
+`/bm-doctor`.
+
+Always end with a one-sentence disclosure that the savings number is heuristic: tools without a
+realistic baseline (memory, document search, git wrappers) report 0 saved.

--- a/.cursor-plugin/commands/bm-stats.md
+++ b/.cursor-plugin/commands/bm-stats.md
@@ -1,16 +1,33 @@
 ---
 name: bm-stats
-description: Show basemind activity dashboard — tool calls, per-tool histogram, estimated tokens saved.
+description: basemind dashboard — resource footprint (disk + RAM) and activity (tool calls, per-tool histogram, estimated tokens saved). Works with or without the MCP server.
 ---
 
-# bm-stats — basemind activity dashboard
+# bm-stats — basemind dashboard
 
-Call the basemind MCP tool `telemetry_summary` and render the result as a
-markdown dashboard.
+Show a basemind dashboard with two sections: **resource footprint** (on-disk size + process RAM) and
+**activity** (tool calls, per-tool histogram, estimated tokens saved). $ARGUMENTS
 
-Default window is `today`. If the user asks for a specific range, map it to one
-of `today`, `1h`, `24h`, `all`.
+Prefer the MCP tools when they're connected, but do **not** depend on them — the CLI reads the same
+data with no server (the MCP server can be reconnecting, or not running at all). If a step's MCP tool
+isn't available, run its CLI equivalent instead of giving up.
 
-Always end with a one-sentence disclosure that the savings number is heuristic:
-tools without a realistic baseline (memory, document search, git wrappers)
-report 0 saved.
+Default window is `today`. If the user asks for a range, map it to one of `today`, `1h`, `24h`, `all`.
+
+1. **Resource footprint.** MCP tool `cache_stats`, or CLI `basemind cache stats` (add `--json` to
+   parse). Report: `total_bytes` (matches `du`), the per-component breakdown (blobs / views /
+   git-history / lance / git-cache / telemetry / other), and process RAM (`rss_bytes` +
+   `peak_rss_bytes`). If `blob_accounting_ok` is `false`, note that orphan accounting was skipped
+   (stale/unreadable index — re-scan to restore it); the sizes are still accurate.
+
+2. **Activity.** MCP tool `telemetry_summary`, or CLI `basemind telemetry --window <today|1h|24h|all>`
+   (add `--json`). Report call count, the per-tool histogram, and estimated tokens saved for the
+   window.
+
+3. **Render** both sections as a compact markdown dashboard.
+
+If neither MCP nor CLI is reachable (no `basemind` binary and no server), say so plainly and point at
+`/bm-doctor`.
+
+Always end with a one-sentence disclosure that the savings number is heuristic: tools without a
+realistic baseline (memory, document search, git wrappers) report 0 saved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Resource footprint in `cache_stats` (disk + RAM).** The `cache_stats` MCP tool and
+  `basemind cache stats` CLI now report a `total_bytes` that reconciles with `du` exactly, a
+  per-component breakdown that **includes the `git-history.fjall/` index** (previously uncounted —
+  the "1.15 GB reported vs 1.5 GB on disk" gap), an `other_bytes` catch-all so an uncounted
+  directory can never silently vanish again, and process memory (`rss_bytes` + `peak_rss_bytes`) via
+  a new cross-platform RSS reader (`src/sysres.rs`; mach on macOS, `/proc` + `getrusage` on Linux).
+  Disk sizing now uses on-disk block counts, so Fjall's sparse journals are no longer over-reported.
+  The Claude statusline gains the on-disk total + serve-process RSS.
+- **Full CLI↔MCP parity.** Every MCP tool an agent can call is now reachable from the CLI: new
+  `git search` (→ `search_git_history`), `governance audit` (→ `memory_audit`), `query expand`
+  (→ `expand`), and a new `shells` group (`spawn`/`send`/`capture`/`kill`/`broadcast`/`list`
+  → the `shell_*` tools, `--features shells`; sessions persist via the shared rmux daemon). Three
+  CLI-only text primitives gained MCP tools — `delta`, `checkpoint`, `detect_waste`. A new
+  `tests/cli_parity.rs` guard enumerates the advertised MCP tool set and fails if any tool lacks a
+  CLI counterpart.
+
+### Fixed
+
+- **Git author/keyword lookups routed to the wrong tool.** `search_git_history` and `recent_changes`
+  descriptions now state their contracts sharply — author/"what did X do"/keyword questions belong
+  to the full-depth `search_git_history` (scans every commit reachable from HEAD), not the bounded
+  100-commit `recent_changes` window. Precision is verified against real `git` at full branch depth
+  by the new `tests/git_parity.rs` harness (opt-in via `BASEMIND_GIT_PARITY_REPO`).
+- **Double-run lock UX.** `basemind scan` / `rescan` now pre-detect a live `basemind serve`/`watch`
+  holding the store lock (via a non-blocking `probe_writer_lock`) and print an actionable notice
+  naming the holder, exiting cleanly instead of colliding with a raw lock error.
+- **Misleading `status` latency.** `status` uses a non-blocking read, so a multi-minute rebuild
+  holding the write lock is no longer recorded as the call's wall-clock; it returns immediately with
+  `rebuild_in_progress: true` when a writer is live.
+- **`cache_stats` no longer hard-fails on a stale/unreadable index.** It reports sizes regardless and
+  flags `blob_accounting_ok: false` when orphan accounting had to be skipped (e.g. a schema-version
+  mismatch), instead of erroring out.
+- **`/bm-stats` works offline.** The plugin command is now CLI-first (like `/bm-doctor`), reading
+  `basemind cache stats` / `basemind telemetry` when the MCP server is disconnected.
+
 ## [0.15.0] — 2026-07-02
 
 Minor release: `RELEASE_MINOR` bumps 14 → 15, so every `.basemind/` index + blob store (including

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,9 @@ dependencies = [
  "insta",
  "jsonschema",
  "lancedb",
+ "libc",
  "lru 0.18.0",
+ "mach2",
  "memchr",
  "notify",
  "notify-debouncer-full",
@@ -6724,6 +6726,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro_rules_attribute"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,10 @@ hex = "0.4"
 ignore = "0.4"
 jsonschema = "0.46"
 lancedb = { version = "0.30", optional = true }
+# Process RSS / peak-RSS reporting (src/sysres.rs): non-deprecated `getrusage` (peak) on all Unix
+# and `/proc/self/statm` (current, Linux). macOS current RSS uses the `mach2` crate below. Windows
+# falls back to `None`.
+libc = "0.2"
 lru = "0.18.0"
 memchr = "2"
 notify = "8"
@@ -190,6 +194,11 @@ tree-sitter = "0.26"
 tree-sitter-language-pack = "=1.12.0"
 url = { version = "2", features = ["serde"], optional = true }
 xberg = { version = "=1.0.0-rc.1", default-features = false, features = ["tokio-runtime", "simd-utf8"], optional = true }
+
+# macOS current-RSS reader (src/sysres.rs) via mach `task_info`. `mach2` is the maintained
+# replacement for libc's deprecated mach bindings; scoped to macOS so no other target pulls it.
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.6"
 
 [dev-dependencies]
 # Criterion microbenchmark harness for the v0.9.0 performance cycle. `html_reports`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ about your code costs a small fraction of the tokens it takes to read the source
 | **Web crawl** | Fetch a page or follow links from a starting URL; results join the document search above. | `web_scrape` · `web_crawl` · `web_map` |
 | **Agent comms** | A shared chat for agents on the same repo: per-repo rooms they auto-join, direct messages, and a recency-filtered inbox. One orchestrator can drive many named subagents (`as_agent`). | `room_post` · `dm_send` · `inbox_read` · `agent_list` |
 | **Agent shells** | Let agents open, type into, and watch terminal sessions in the background. | `shell_spawn` · `shell_send` · `shell_capture` · `shell_list` |
-| **Token saving** | Hand an agent a file's outline instead of its full text, then pull back only the one function it needs. | `compress` · `expand` |
+| **Token saving** | Hand an agent a file's outline instead of its full text, pull back only the one function it needs, diff a re-read instead of resending it whole, checkpoint a session, and flag wasteful tool use. | `compress` · `expand` · `delta` · `checkpoint` · `detect_waste` |
 | **Admin** | Refresh the index, see what's been queried, and check or clean up the on-disk cache. | `rescan` · `telemetry_summary` · `cache_stats` |
 
 <!-- markdownlint-enable MD013 -->

--- a/README.md
+++ b/README.md
@@ -474,9 +474,10 @@ variables in the obvious way: `--llm-api-key` becomes `BASEMIND_LLM_API_KEY`.
 ## CLI reference
 
 <details>
-<summary><strong>Full command list</strong> — query · git · memory · suggestions · cache · web · comms</summary>
+<summary><strong>Full command list</strong> — query · git · memory · suggestions · cache · web · comms · shells</summary>
 
-CLI commands mirror the MCP tools. Add `--json` for machine-readable output.
+CLI commands mirror the MCP tools 1:1 (enforced by `tests/cli_parity.rs`). Add `--json` for
+machine-readable output.
 
 <!-- markdownlint-disable MD013 -->
 
@@ -495,6 +496,7 @@ CLI commands mirror the MCP tools. Add `--json` for machine-readable output.
 | `list-files [--path-contains --language]` | List indexed files. |
 | `status` / `repo-info` | Project overview / git info (branch, HEAD, origin). |
 | `dependents <module>` | What imports a given module. |
+| `expand <path> <name> [--kind]` | A symbol's raw source body (the inverse of an outline entry). |
 
 **Git (`basemind git`)**
 
@@ -502,6 +504,7 @@ CLI commands mirror the MCP tools. Add `--json` for machine-readable output.
 |---|---|
 | `working-tree-status` | What's staged and unstaged right now. |
 | `recent-changes [--limit]` | Recent commits with their files. |
+| `search <pattern> [--field author\|message\|all] [--limit]` | Full-text search over commit history at full branch depth. |
 | `commits-touching <path>` / `find-commits-by-path <pattern>` | Commits for a path or pattern. |
 | `hot-files [--limit]` | The most frequently changed files. |
 | `diff-file <path> <old> <new>` / `diff-outline <path> [--rev]` | File or structure diff across commits. |
@@ -524,12 +527,13 @@ CLI commands mirror the MCP tools. Add `--json` for machine-readable output.
 | `mine [--commits --min-count --min-confidence --max-files]` | Suggest notes from files that change together. |
 | `proposals [--kind --limit]` | List pending suggestions. |
 | `accept <id> [--key]` / `reject <id> [--reason]` | Keep a suggestion / dismiss it for good. |
+| `audit [--key --individual --dry-run --include-archived]` | Recompute memory importance, archive stale entries, refresh verdicts. |
 
 **Cache (`basemind cache`)**
 
 | Command | Purpose |
 |---|---|
-| `stats` | How much space the cache uses. |
+| `stats` | Disk footprint (per-component + total, matches `du`) and process RAM. |
 | `gc` | Reclaim unused space (safe while the server runs). |
 | `clear --component <comp>` | Clear part of the cache (`views`, `blobs`, `git-cache`, `all`, …). |
 
@@ -551,6 +555,16 @@ CLI commands mirror the MCP tools. Add `--json` for machine-readable output.
 | `read <id>` | Read one message in full. |
 | `register --name <handle>` / `agents` | Set your handle / list active agents. |
 | `status` / `start` / `stop` | The shared service: check, start, or stop it. |
+
+**Shells (`basemind shells`, `--features shells`)**
+
+| Command | Purpose |
+|---|---|
+| `spawn <command> [--cwd --env --title]` | Start a detached headless shell session; prints a `session_id`. |
+| `send <session-id> <text> [--no-enter]` | Type into a session's stdin. |
+| `capture <session-id> [--lines]` | Read a session's visible screen. |
+| `kill <session-id>` / `list` | End a session / list live sessions. |
+| `broadcast <text> --session <id>…` | Send the same input to several sessions at once. |
 
 **Other commands (`scan`, `serve`, `watch`, …)**
 

--- a/commands/bm-stats.md
+++ b/commands/bm-stats.md
@@ -1,16 +1,33 @@
 ---
 name: bm-stats
-description: Show basemind activity dashboard — tool calls, per-tool histogram, estimated tokens saved.
+description: basemind dashboard — resource footprint (disk + RAM) and activity (tool calls, per-tool histogram, estimated tokens saved). Works with or without the MCP server.
 ---
 
-# bm-stats — basemind activity dashboard
+# bm-stats — basemind dashboard
 
-Call the basemind MCP tool `telemetry_summary` and render the result as a
-markdown dashboard.
+Show a basemind dashboard with two sections: **resource footprint** (on-disk size + process RAM) and
+**activity** (tool calls, per-tool histogram, estimated tokens saved). $ARGUMENTS
 
-Default window is `today`. If the user asks for a specific range, map it to one
-of `today`, `1h`, `24h`, `all`.
+Prefer the MCP tools when they're connected, but do **not** depend on them — the CLI reads the same
+data with no server (the MCP server can be reconnecting, or not running at all). If a step's MCP tool
+isn't available, run its CLI equivalent instead of giving up.
 
-Always end with a one-sentence disclosure that the savings number is heuristic:
-tools without a realistic baseline (memory, document search, git wrappers)
-report 0 saved.
+Default window is `today`. If the user asks for a range, map it to one of `today`, `1h`, `24h`, `all`.
+
+1. **Resource footprint.** MCP tool `cache_stats`, or CLI `basemind cache stats` (add `--json` to
+   parse). Report: `total_bytes` (matches `du`), the per-component breakdown (blobs / views /
+   git-history / lance / git-cache / telemetry / other), and process RAM (`rss_bytes` +
+   `peak_rss_bytes`). If `blob_accounting_ok` is `false`, note that orphan accounting was skipped
+   (stale/unreadable index — re-scan to restore it); the sizes are still accurate.
+
+2. **Activity.** MCP tool `telemetry_summary`, or CLI `basemind telemetry --window <today|1h|24h|all>`
+   (add `--json`). Report call count, the per-tool histogram, and estimated tokens saved for the
+   window.
+
+3. **Render** both sections as a compact markdown dashboard.
+
+If neither MCP nor CLI is reachable (no `basemind` binary and no server), say so plainly and point at
+`/bm-doctor`.
+
+Always end with a one-sentence disclosure that the savings number is heuristic: tools without a
+realistic baseline (memory, document search, git wrappers) report 0 saved.

--- a/opencode-plugin/commands/bm-stats.md
+++ b/opencode-plugin/commands/bm-stats.md
@@ -1,16 +1,33 @@
 ---
 name: bm-stats
-description: Show basemind activity dashboard — tool calls, per-tool histogram, estimated tokens saved.
+description: basemind dashboard — resource footprint (disk + RAM) and activity (tool calls, per-tool histogram, estimated tokens saved). Works with or without the MCP server.
 ---
 
-# bm-stats — basemind activity dashboard
+# bm-stats — basemind dashboard
 
-Call the basemind MCP tool `telemetry_summary` and render the result as a
-markdown dashboard.
+Show a basemind dashboard with two sections: **resource footprint** (on-disk size + process RAM) and
+**activity** (tool calls, per-tool histogram, estimated tokens saved). $ARGUMENTS
 
-Default window is `today`. If the user asks for a specific range, map it to one
-of `today`, `1h`, `24h`, `all`.
+Prefer the MCP tools when they're connected, but do **not** depend on them — the CLI reads the same
+data with no server (the MCP server can be reconnecting, or not running at all). If a step's MCP tool
+isn't available, run its CLI equivalent instead of giving up.
 
-Always end with a one-sentence disclosure that the savings number is heuristic:
-tools without a realistic baseline (memory, document search, git wrappers)
-report 0 saved.
+Default window is `today`. If the user asks for a range, map it to one of `today`, `1h`, `24h`, `all`.
+
+1. **Resource footprint.** MCP tool `cache_stats`, or CLI `basemind cache stats` (add `--json` to
+   parse). Report: `total_bytes` (matches `du`), the per-component breakdown (blobs / views /
+   git-history / lance / git-cache / telemetry / other), and process RAM (`rss_bytes` +
+   `peak_rss_bytes`). If `blob_accounting_ok` is `false`, note that orphan accounting was skipped
+   (stale/unreadable index — re-scan to restore it); the sizes are still accurate.
+
+2. **Activity.** MCP tool `telemetry_summary`, or CLI `basemind telemetry --window <today|1h|24h|all>`
+   (add `--json`). Report call count, the per-tool histogram, and estimated tokens saved for the
+   window.
+
+3. **Render** both sections as a compact markdown dashboard.
+
+If neither MCP nor CLI is reachable (no `basemind` binary and no server), say so plainly and point at
+`/bm-doctor`.
+
+Always end with a one-sentence disclosure that the savings number is heuristic: tools without a
+realistic baseline (memory, document search, git wrappers) report 0 saved.

--- a/src/cli/codemap.rs
+++ b/src/cli/codemap.rs
@@ -119,6 +119,16 @@ pub enum QueryCmd {
     RepoInfo,
     /// Files whose imports mention the given module (heuristic).
     Dependents { module: String },
+    /// Expand a symbol to its raw source body (the inverse of an outline entry).
+    Expand {
+        /// Repository-relative path of the indexed file.
+        path: String,
+        /// Symbol name (matched exactly, case-sensitive).
+        name: String,
+        /// Kind filter to disambiguate (e.g. `function`, `struct`, `method`).
+        #[arg(long)]
+        kind: Option<String>,
+    },
 }
 
 pub async fn run(
@@ -288,6 +298,15 @@ pub async fn run(
                 server.dependents(Parameters(Lenient(p))).await,
             )?;
             emit("dependents", &r, json, out)
+        }
+        QueryCmd::Expand { path, name, kind } => {
+            let p = ExpandParams {
+                path: resolve_path(server, &path),
+                name,
+                kind,
+            };
+            let r = run_tool("expand", server.expand(Parameters(p)).await)?;
+            emit("expand", &r, json, out)
         }
     }
 }

--- a/src/cli/git.rs
+++ b/src/cli/git.rs
@@ -26,6 +26,20 @@ pub enum GitCmd {
         #[arg(long)]
         no_files: bool,
     },
+    /// Full-text search over commit history (author / message / all) at full branch depth.
+    /// This is the "what did <author> do" / "which commit mentions <X>" tool — it scans every
+    /// commit reachable from HEAD, not a recent window.
+    Search {
+        /// Query tokens (lowercased, split on non-alphanumeric) matched as an AND.
+        pattern: String,
+        /// Field to search: `author` (name + email), `message` (summary + body), or `all`
+        /// (default).
+        #[arg(long)]
+        field: Option<String>,
+        /// Max commits to return (default 20, max 100).
+        #[arg(long)]
+        limit: Option<u32>,
+    },
     /// Commits that modified a given path.
     CommitsTouching {
         path: String,
@@ -119,6 +133,23 @@ pub async fn run(
             };
             let r = run_tool("recent_changes", server.recent_changes(Parameters(p)).await)?;
             emit("recent_changes", &r, json, out)
+        }
+        GitCmd::Search {
+            pattern,
+            field,
+            limit,
+        } => {
+            let p = SearchGitHistoryParams {
+                pattern,
+                field,
+                limit,
+                cursor: None,
+            };
+            let r = run_tool(
+                "search_git_history",
+                server.search_git_history(Parameters(p)).await,
+            )?;
+            emit("search_git_history", &r, json, out)
         }
         GitCmd::CommitsTouching { path, limit } => {
             let p = CommitsTouchingParams {

--- a/src/cli/governance.rs
+++ b/src/cli/governance.rs
@@ -57,6 +57,25 @@ pub enum GovernanceCmd {
         #[arg(long)]
         reason: Option<String>,
     },
+    /// Audit shared/individual memory records: recompute importance, archive stale entries,
+    /// refresh `verified` verdicts (needs `--features memory`).
+    Audit {
+        /// Audit exactly this one key instead of the whole scope.
+        #[arg(long)]
+        key: Option<String>,
+        /// Memory tier: `individual` (per-agent) instead of the default shared `group`.
+        #[arg(long)]
+        individual: bool,
+        /// Compute verdicts but persist no mutations.
+        #[arg(long)]
+        dry_run: bool,
+        /// Maximum records to audit (default 100, max 1000).
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Also scan the archived/stale `memory_archive` keyspace.
+        #[arg(long)]
+        include_archived: bool,
+    },
 }
 
 pub async fn run(
@@ -105,6 +124,27 @@ pub async fn run(
                 server.proposal_reject(Parameters(p)).await,
             )?;
             emit("proposal_reject", &r, json, out)
+        }
+        GovernanceCmd::Audit {
+            key,
+            individual,
+            dry_run,
+            limit,
+            include_archived,
+        } => {
+            let p = MemoryAuditParams {
+                key,
+                visibility: if individual {
+                    Visibility::Individual
+                } else {
+                    Visibility::Group
+                },
+                dry_run,
+                limit,
+                include_archived,
+            };
+            let r = run_tool("memory_audit", server.memory_audit(Parameters(p)).await)?;
+            emit("memory_audit", &r, json, out)
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,8 @@ pub mod git;
 pub mod governance;
 pub mod memory;
 pub mod render;
+#[cfg(all(feature = "shells", any(unix, windows)))]
+pub mod shells;
 pub mod web;
 
 use std::io::Write;
@@ -52,6 +54,11 @@ pub enum ToolCmd {
     /// On-demand web ingestion (needs `--features crawl`).
     #[command(subcommand)]
     Web(web::WebCmd),
+    /// Headless agent shells: spawn / send / capture / kill / broadcast / list
+    /// (needs `--features shells`).
+    #[cfg(all(feature = "shells", any(unix, windows)))]
+    #[command(subcommand)]
+    Shells(shells::ShellsCmd),
     /// Aggregate telemetry into a usage summary.
     Telemetry {
         /// Aggregation window: `today` (default), `1h`, `24h`, `all`.
@@ -99,6 +106,8 @@ pub fn run(
             ToolCmd::Memory(m) => memory::run(&server, m, json, &mut out).await?,
             ToolCmd::Governance(g) => governance::run(&server, g, json, &mut out).await?,
             ToolCmd::Web(w) => web::run(&server, w, json, &mut out).await?,
+            #[cfg(all(feature = "shells", any(unix, windows)))]
+            ToolCmd::Shells(s) => shells::run(&server, s, json, &mut out).await?,
             ToolCmd::Telemetry { window, tool } => {
                 admin::run_telemetry(&server, window, tool, json, &mut out).await?
             }

--- a/src/cli/shells.rs
+++ b/src/cli/shells.rs
@@ -1,0 +1,159 @@
+//! Headless agent-shell subcommands: 1:1 with the `shell_*` MCP tools.
+//!
+//! Each handler builds the matching `Shell*Params` struct and dispatches to the
+//! identical `#[tool]` method on the in-process [`BasemindServer`]. Sessions are
+//! backed by the embedded rmux daemon (an external process basemind re-execs
+//! itself as), so a session spawned from one CLI invocation survives the process
+//! exit and is addressable from the next — the same daemon a running `serve`
+//! shares. Gated on `feature = "shells"`.
+
+use std::io::Write;
+
+use anyhow::{Result, anyhow};
+use clap::Subcommand;
+
+use crate::mcp::BasemindServer;
+use crate::mcp::params::*;
+
+use super::render::emit;
+use super::run_tool;
+
+#[derive(Subcommand, Debug)]
+pub enum ShellsCmd {
+    /// Spawn a detached headless shell session and print its `session_id`.
+    Spawn {
+        /// Command line to run in the session's initial pane (via the login shell).
+        command: String,
+        /// Repository-relative working directory (forward-slash, no leading `/`).
+        #[arg(long)]
+        cwd: Option<String>,
+        /// Environment override in `KEY=VALUE` form. Repeatable.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
+        /// Advisory human-readable session title.
+        #[arg(long)]
+        title: Option<String>,
+    },
+    /// Write text to a session's stdin (a trailing newline is appended unless `--no-enter`).
+    Send {
+        /// The `session_id` returned by `spawn`.
+        session_id: String,
+        /// Text to write to the session's stdin.
+        text: String,
+        /// Send the text as a raw keystroke fragment without a trailing newline.
+        #[arg(long)]
+        no_enter: bool,
+    },
+    /// Capture the visible screen of a session.
+    Capture {
+        /// The `session_id` returned by `spawn`.
+        session_id: String,
+        /// Return only the last N non-blank lines (omit for the whole visible screen).
+        #[arg(long)]
+        lines: Option<usize>,
+    },
+    /// Kill a session.
+    Kill {
+        /// The `session_id` returned by `spawn`.
+        session_id: String,
+    },
+    /// Write the same text to several sessions' stdin at once.
+    Broadcast {
+        /// Text to write to each session's stdin.
+        text: String,
+        /// Target `session_id`s. Repeatable; every id must be a live session.
+        #[arg(long = "session", value_name = "SESSION_ID", required = true)]
+        session_ids: Vec<String>,
+        /// Send the text as a raw keystroke fragment without a trailing newline.
+        #[arg(long)]
+        no_enter: bool,
+    },
+    /// List the sessions this server has spawned, with liveness.
+    List,
+}
+
+/// Parse a `KEY=VALUE` override into a [`ShellEnv`]. The value may itself contain
+/// `=`; only the first `=` splits the pair.
+fn parse_env(raw: &str) -> Result<ShellEnv> {
+    let (key, value) = raw
+        .split_once('=')
+        .ok_or_else(|| anyhow!("invalid --env {raw:?}: expected KEY=VALUE"))?;
+    Ok(ShellEnv {
+        key: key.to_string(),
+        value: value.to_string(),
+    })
+}
+
+pub async fn run(
+    server: &BasemindServer,
+    cmd: ShellsCmd,
+    json: bool,
+    out: &mut impl Write,
+) -> Result<()> {
+    match cmd {
+        ShellsCmd::Spawn {
+            command,
+            cwd,
+            env,
+            title,
+        } => {
+            let env = if env.is_empty() {
+                None
+            } else {
+                Some(env.iter().map(|e| parse_env(e)).collect::<Result<_>>()?)
+            };
+            let p = ShellSpawnParams {
+                command,
+                cwd: cwd.map(|c| c.as_str().into()),
+                env,
+                title,
+            };
+            let r = run_tool("shell_spawn", server.shell_spawn(Parameters(p)).await)?;
+            emit("shell_spawn", &r, json, out)
+        }
+        ShellsCmd::Send {
+            session_id,
+            text,
+            no_enter,
+        } => {
+            let p = ShellSendParams {
+                session_id,
+                text,
+                enter: !no_enter,
+            };
+            let r = run_tool("shell_send", server.shell_send(Parameters(p)).await)?;
+            emit("shell_send", &r, json, out)
+        }
+        ShellsCmd::Capture { session_id, lines } => {
+            let p = ShellCaptureParams { session_id, lines };
+            let r = run_tool("shell_capture", server.shell_capture(Parameters(p)).await)?;
+            emit("shell_capture", &r, json, out)
+        }
+        ShellsCmd::Kill { session_id } => {
+            let p = ShellKillParams { session_id };
+            let r = run_tool("shell_kill", server.shell_kill(Parameters(p)).await)?;
+            emit("shell_kill", &r, json, out)
+        }
+        ShellsCmd::Broadcast {
+            text,
+            session_ids,
+            no_enter,
+        } => {
+            let p = ShellBroadcastParams {
+                session_ids,
+                text,
+                enter: !no_enter,
+            };
+            let r = run_tool(
+                "shell_broadcast",
+                server.shell_broadcast(Parameters(p)).await,
+            )?;
+            emit("shell_broadcast", &r, json, out)
+        }
+        ShellsCmd::List => {
+            let p = ShellListParams {};
+            let r = run_tool("shell_list", server.shell_list(Parameters(p)).await)?;
+            emit("shell_list", &r, json, out)
+        }
+    }
+}

--- a/src/git_history/mod.rs
+++ b/src/git_history/mod.rs
@@ -56,7 +56,9 @@ use crate::path::RelPath;
 /// feature, so the bump only forces in-flight dev indexes to rebuild.
 pub const GIT_HISTORY_SCHEMA: u32 = crate::version::RELEASE_MINOR as u32 + 5;
 
-const GIT_HISTORY_DIR: &str = "git-history.fjall";
+/// On-disk directory name of the git-history index under `.basemind/`. `pub(crate)` so the cache
+/// accounting in [`crate::store_gc::cache_stats`] can size it (it is a sibling of `views/`).
+pub(crate) const GIT_HISTORY_DIR: &str = "git-history.fjall";
 
 /// Retry budget + backoff for a transient fjall `Locked` when opening the git-history DB. The
 /// caller is writer-gated, so any `Locked` is a short-lived concurrent open that clears — mirrors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod shells;
 pub mod store;
 pub mod store_blob;
 pub mod store_gc;
+mod store_lock;
 pub mod sysres;
 pub mod textcompress;
 #[cfg(feature = "crawl")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod shells;
 pub mod store;
 pub mod store_blob;
 pub mod store_gc;
+pub mod sysres;
 pub mod textcompress;
 #[cfg(feature = "crawl")]
 pub mod url;

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,6 +537,28 @@ fn open_store_for_write(
     })
 }
 
+/// Pre-flight the store write lock before a CLI `scan` / `rescan`. When a live basemind process
+/// already holds it — overwhelmingly the "editor plugin runs `serve` while the user (or another
+/// plugin command) runs `scan`" double-run — return an actionable message so the caller prints it
+/// and exits cleanly, instead of blocking on the acquire retries and then failing with a raw lock
+/// error. `None` means the lock is free (proceed); the acquire still handles the probe→acquire race
+/// reactively via [`basemind::store::LOCK_CONTENTION_HELP`].
+fn writer_collision_notice(root: &std::path::Path) -> Option<String> {
+    let basemind_dir = root.join(basemind::config::BASEMIND_DIR);
+    match basemind::store::probe_writer_lock(&basemind_dir) {
+        basemind::store::WriterProbe::Free => None,
+        basemind::store::WriterProbe::Held { holder: Some(meta) } => Some(format!(
+            "`{}` (pid {}) is already running against this repo and keeping the index fresh — \
+             running this directly is unnecessary and would collide with it. Use that server's \
+             `rescan` tool to refresh the index, or stop it first.",
+            meta.command, meta.pid
+        )),
+        basemind::store::WriterProbe::Held { holder: None } => {
+            Some(basemind::store::LOCK_CONTENTION_HELP.to_string())
+        }
+    }
+}
+
 /// Build / refresh the repo-global git-history index after a working-tree scan (a separate phase
 /// from the core file scan). Best-effort: a non-git dir, a disabled toggle, or any failure leaves
 /// the index untouched and the history tools fall back to the live walk — never fails the scan.
@@ -639,6 +661,12 @@ fn cmd_scan(
         return Ok(());
     }
 
+    if let Some(notice) = writer_collision_notice(root) {
+        use std::io::Write as _;
+        render::render_scan_header(&mut out, "scan", verbosity);
+        let _ = writeln!(out, "{notice}");
+        return Ok(());
+    }
     let mut store = open_store_for_write(
         root,
         basemind::store::VIEW_WORKING,
@@ -672,13 +700,18 @@ fn cmd_rescan(
 ) -> Result<()> {
     bootstrap_grammars(verbosity, no_color)?;
     let config = load_or_default(root)?;
+    let mut out = render::stdout(no_color);
+    if let Some(notice) = writer_collision_notice(root) {
+        use std::io::Write as _;
+        let _ = writeln!(out, "{notice}");
+        return Ok(());
+    }
     let mut store = open_store_for_write(
         root,
         basemind::store::VIEW_WORKING,
         "rescan",
         LockHolder::Rescan,
     )?;
-    let mut out = render::stdout(no_color);
 
     // `--full` or no paths → full working-tree re-index. Otherwise re-index only the
     // supplied paths incrementally. `scan_paths` resolves paths against `root`, so make

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,11 @@ enum Cmd {
     /// On-demand web ingestion (needs `--features crawl`).
     #[command(subcommand)]
     Web(basemind::cli::web::WebCmd),
+    /// Headless agent shells: spawn / send / capture / kill / broadcast / list
+    /// (needs `--features shells`).
+    #[cfg(all(feature = "shells", any(unix, windows)))]
+    #[command(subcommand)]
+    Shells(basemind::cli::shells::ShellsCmd),
     /// Aggregate telemetry into a usage summary.
     Telemetry {
         /// Aggregation window: `today` (default), `1h`, `24h`, `all`.
@@ -306,6 +311,8 @@ fn main() -> Result<()> {
         Cmd::Memory(m) => dispatch(basemind::cli::ToolCmd::Memory(m)),
         Cmd::Governance(g) => dispatch(basemind::cli::ToolCmd::Governance(g)),
         Cmd::Web(w) => dispatch(basemind::cli::ToolCmd::Web(w)),
+        #[cfg(all(feature = "shells", any(unix, windows)))]
+        Cmd::Shells(s) => dispatch(basemind::cli::ToolCmd::Shells(s)),
         Cmd::Telemetry { window, tool } => {
             dispatch(basemind::cli::ToolCmd::Telemetry { window, tool })
         }
@@ -437,6 +444,7 @@ fn warn_ignored_global_flags(cmd: &Cmd, json: bool, view: &str) {
         Cmd::Query(_)
             | Cmd::Git(_)
             | Cmd::Memory(_)
+            | Cmd::Governance(_)
             | Cmd::Web(_)
             | Cmd::Telemetry { .. }
             | Cmd::Cache(_)
@@ -445,6 +453,9 @@ fn warn_ignored_global_flags(cmd: &Cmd, json: bool, view: &str) {
     // consume the flag too. Feature-gated to match the `Cmd::Comms` definition.
     #[cfg(all(feature = "comms", any(unix, windows)))]
     let consumes_json = consumes_json || matches!(cmd, Cmd::Comms { .. });
+    // Shell verbs render through `emit`, honoring `--json`. Feature-gated to match `Cmd::Shells`.
+    #[cfg(all(feature = "shells", any(unix, windows)))]
+    let consumes_json = consumes_json || matches!(cmd, Cmd::Shells(_));
     let consumes_view = consumes_json || matches!(cmd, Cmd::Serve(_));
 
     if json && !consumes_json {

--- a/src/mcp/helpers_compress.rs
+++ b/src/mcp/helpers_compress.rs
@@ -33,7 +33,10 @@ use rmcp::ErrorData as McpError;
 use super::ServerState;
 use super::helpers::{json_result, kind_to_str, parse_kind};
 use super::tokens;
-use super::types_compress::{CompressParams, CompressResponse, ExpandParams, ExpandResponse};
+use super::types_compress::{
+    CheckpointParams, CompressParams, CompressResponse, DeltaParams, DetectWasteParams,
+    ExpandParams, ExpandResponse,
+};
 use crate::query;
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -383,6 +386,69 @@ fn run_prose(
     };
 
     json_result(&response)
+}
+
+// ─── delta ───────────────────────────────────────────────────────────────────
+
+/// Compute a compact line-diff from `params.old` to `params.new` via the stateless
+/// `textcompress::delta` primitive and return the [`crate::textcompress::delta::DeltaOutcome`]
+/// verbatim.
+pub(super) async fn run_delta(
+    _state: &ServerState,
+    params: DeltaParams,
+) -> Result<rmcp::model::CallToolResult, McpError> {
+    let outcome = crate::textcompress::delta::delta(&params.old, &params.new);
+    json_result(&outcome)
+}
+
+// ─── checkpoint ──────────────────────────────────────────────────────────────
+
+/// List the working-tree change set (staged + modified + untracked) for this server's repo,
+/// mirroring `textcompress::cli::changed_files`. Fail-open: no repo, or any git error, yields
+/// an empty list — a checkpoint must never fail just because the working tree is unreadable.
+fn changed_files(state: &ServerState) -> Vec<String> {
+    let Some(repo) = state.repo.as_ref() else {
+        return Vec::new();
+    };
+    let Ok(status) = repo.status_porcelain() else {
+        return Vec::new();
+    };
+    status
+        .staged_added
+        .iter()
+        .chain(&status.staged_modified)
+        .chain(&status.staged_deleted)
+        .chain(&status.modified)
+        .chain(&status.untracked)
+        .map(|p| p.to_string())
+        .collect()
+}
+
+/// Extract a credential-safe [`crate::textcompress::checkpoint::Checkpoint`] from session
+/// `params.text`. `files_changed` is fetched from this repo's git working tree (never scraped
+/// from `text`); see [`changed_files`] for the fail-open contract.
+pub(super) async fn run_checkpoint(
+    state: &ServerState,
+    params: CheckpointParams,
+) -> Result<rmcp::model::CallToolResult, McpError> {
+    let files_changed = changed_files(state);
+    let checkpoint =
+        crate::textcompress::checkpoint::extract_checkpoint(&params.text, files_changed);
+    json_result(&checkpoint)
+}
+
+// ─── detect_waste ────────────────────────────────────────────────────────────
+
+/// Parse `params.log` as JSON-Lines tool calls (leniently — malformed or `tool`-less lines are
+/// skipped) and run the pure `textcompress::waste::detect_waste` analysis, returning the
+/// [`crate::textcompress::waste::WasteReport`] verbatim.
+pub(super) async fn run_detect_waste(
+    _state: &ServerState,
+    params: DetectWasteParams,
+) -> Result<rmcp::model::CallToolResult, McpError> {
+    let calls = crate::textcompress::waste::parse_calls(&params.log);
+    let report = crate::textcompress::waste::detect_waste(&calls);
+    json_result(&report)
 }
 
 // ─── Unit tests ──────────────────────────────────────────────────────────────

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -104,8 +104,9 @@ pub mod params {
         BlameFileParams, BlameSymbolParams, CommitsTouchingParams, DependentsParams,
         DiffFileParams, DiffOutlineParams, FindCallersParams, FindCommitsByPathParams,
         FindReferencesParams, HotFilesParams, ListFilesParams, OutlineParams, RecentChangesParams,
-        RepoInfoParams, RescanParams, SearchDocumentsParams, SearchSymbolsParams, StatusParams,
-        SymbolHistoryParams, TelemetrySummaryParams, WorkingTreeStatusParams, WorkspaceGrepParams,
+        RepoInfoParams, RescanParams, SearchDocumentsParams, SearchGitHistoryParams,
+        SearchSymbolsParams, StatusParams, SymbolHistoryParams, TelemetrySummaryParams,
+        WorkingTreeStatusParams, WorkspaceGrepParams,
     };
     #[cfg(feature = "crawl")]
     pub use super::types::{WebCrawlParams, WebMapParams, WebScrapeParams};
@@ -119,6 +120,11 @@ pub mod params {
     pub use super::types_memory::{
         MemoryDeleteParams, MemoryGetParams, MemoryListParams, MemoryPutParams, MemorySearchParams,
         Visibility,
+    };
+    #[cfg(all(feature = "shells", any(unix, windows)))]
+    pub use super::types_shells::{
+        ShellBroadcastParams, ShellCaptureParams, ShellEnv, ShellKillParams, ShellListParams,
+        ShellSendParams, ShellSpawnParams,
     };
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -689,6 +689,17 @@ impl BasemindServer {
             prompt_router: Self::prompt_router(),
         }
     }
+
+    /// Names of every tool this server advertises via `tools/list` (the full router, ignoring the
+    /// `BASEMIND_MCP_LEAN` wrapper mode). Exposed for the `tests/cli_parity.rs` guard, which asserts
+    /// each advertised tool has a CLI counterpart. The set follows the compiled feature flags.
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tool_router
+            .list_all()
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect()
+    }
 }
 
 #[tool_handler(router = self.tool_router.clone())]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -111,6 +111,7 @@ pub mod params {
     #[cfg(feature = "crawl")]
     pub use super::types::{WebCrawlParams, WebMapParams, WebScrapeParams};
     pub use super::types_admin::{CacheClearParams, CacheGcParams, CacheStatsParams};
+    pub use super::types_compress::ExpandParams;
     pub use super::types_governance::{
         MemoryAuditParams, ProposalAcceptParams, ProposalRejectParams, ProposalsListParams,
         ProposalsMineParams,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -508,7 +508,40 @@ impl BasemindServer {
         let __started = std::time::Instant::now();
         let __params_json = Value::Null;
         let __result: Result<CallToolResult, McpError> = async {
-            let store = self.state.store.read().await;
+            // Non-blocking read: a writer (`scan`/`rescan`/`watch`) can hold the store lock for
+            // minutes during a rebuild. `read().await` would queue behind it and record the
+            // whole lock-wait as this call's wall-clock (the misleading multi-minute `status`
+            // latency). `try_read` fails fast instead — we report `rebuild_in_progress` with a
+            // fresh on-disk blob tally and skip the index-derived counts rather than block.
+            let store = match self.state.store.try_read() {
+                Ok(store) => store,
+                Err(_) => {
+                    let basemind_dir = self.state.root.join(crate::config::BASEMIND_DIR);
+                    return json_result(&StatusResponse {
+                        file_count: 0,
+                        blob_count: count_fm_blobs(&basemind_dir),
+                        note: Some(
+                            "a rebuild is in progress (another basemind process holds the store \
+                             lock); index counts are unavailable until it completes"
+                                .to_string(),
+                        ),
+                        rebuild_in_progress: true,
+                        total_size_bytes: 0,
+                        languages: BTreeMap::new(),
+                        cache_dir: crate::lang::grammar_cache_dir()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|| "(unresolved)".to_string()),
+                        schema_version: crate::extract::SCHEMA_VER,
+                        root: self.state.root.display().to_string(),
+                        submodules: self
+                            .state
+                            .repo
+                            .as_ref()
+                            .map(|r| r.submodule_paths())
+                            .unwrap_or_default(),
+                    });
+                }
+            };
             // Count into a borrowed-key map to avoid one String::clone() per file.
             // The store lock is held for the entire loop, so &str borrows into the
             // store are valid. Convert to BTreeMap<String,usize> once at the end —
@@ -541,6 +574,7 @@ impl BasemindServer {
                 file_count,
                 blob_count,
                 note,
+                rebuild_in_progress: false,
                 total_size_bytes: total_size,
                 languages: by_lang,
                 cache_dir,

--- a/src/mcp/tools_admin.rs
+++ b/src/mcp/tools_admin.rs
@@ -81,10 +81,13 @@ impl BasemindServer {
     }
 
     #[tool(
-        description = "On-disk size + blob accounting for the `.basemind/` cache: recursive byte \
-            sizes per component (blobs / views / lance / git-cache / telemetry), total blob-file \
-            count, orphaned-blob count (unreferenced, reclaimable via `cache_gc`), and per-view \
-            indexed file counts. Read-only; safe anytime.",
+        description = "Resource footprint of basemind: on-disk size + blob accounting + process \
+            RAM. Reports recursive byte sizes per component (blobs / views / lance / git-cache / \
+            telemetry / git-history), the ground-truth `total_bytes` for the whole `.basemind/` \
+            tree (matches `du`) with the unattributed remainder in `other_bytes`, total blob-file \
+            count, orphaned-blob count (unreferenced, reclaimable via `cache_gc`), per-view indexed \
+            file counts, and the serving process's current + peak RSS (`rss_bytes` / \
+            `peak_rss_bytes`). Read-only; safe anytime.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     pub(crate) async fn cache_stats(

--- a/src/mcp/tools_compress.rs
+++ b/src/mcp/tools_compress.rs
@@ -9,7 +9,9 @@ use rmcp::tool;
 
 use super::BasemindServer;
 use super::helpers::record_call;
-use super::types_compress::{CompressParams, ExpandParams};
+use super::types_compress::{
+    CheckpointParams, CompressParams, DeltaParams, DetectWasteParams, ExpandParams,
+};
 
 #[rmcp::tool_router(vis = "pub(super)", router = "tool_router_compress")]
 impl BasemindServer {
@@ -71,6 +73,100 @@ impl BasemindServer {
         record_call(
             &self.state,
             "compress",
+            &__params_json,
+            __started,
+            &__result,
+        );
+        __result
+    }
+
+    #[tool(
+        description = "Compute a compact +N/-M line-diff from `old` to `new` — the stateless \
+            re-read primitive: when re-reading content you've already seen, emit only what \
+            changed instead of the full text. Both sides are supplied inline (unlike the CLI, \
+            which reads `old` from a file). Identical inputs return `changed=false` with a \
+            `# unchanged` marker. Either side over 50,000 bytes or 2,000 lines bails to a full \
+            re-read: `bailed=true`, `output` carries the NEW content verbatim behind a marker, \
+            and `added`/`removed` are 0. Otherwise an LCS line diff runs and `output` is a \
+            `+A/-R` header followed by `-`/`+` lines for the changed regions only; common lines \
+            are omitted. Pure and stateless — it does not know what the caller has previously \
+            seen; the caller supplies both sides.",
+        annotations(read_only_hint = true, open_world_hint = false)
+    )]
+    pub(crate) async fn delta(
+        &self,
+        Parameters(p): Parameters<DeltaParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let __started = std::time::Instant::now();
+        let __params_json = serde_json::to_value(&p).unwrap_or(serde_json::Value::Null);
+        let __result: Result<CallToolResult, McpError> =
+            super::helpers_compress::run_delta(&self.state, p).await;
+        record_call(&self.state, "delta", &__params_json, __started, &__result);
+        __result
+    }
+
+    #[tool(
+        description = "Extract decisions, errors, and changed files from session `text` (a \
+            transcript chunk or concatenated tool output) into a compact, credential-safe \
+            checkpoint — persist or re-inject this instead of the whole session. \
+            `decisions` are lines matching conservative decision markers (decided/chose/\
+            \"we will\"/\"going with\"/opted for/conclusion:/TODO/FIXME); `errors` are lines \
+            matching the error-line heuristic. `files_changed` comes from THIS server's git \
+            working tree (staged + modified + untracked paths at call time) — never scraped \
+            from `text`. Any candidate line that embeds a credential (API key, token, etc.) is \
+            dropped entirely from every field before it can be returned. Each list is capped \
+            (decisions/errors 50, files 200); a list that exceeded its cap sets the matching \
+            `*_truncated` flag. Fails open on git: if this server is not running inside a git \
+            repository (or git errors), `files_changed` is simply empty — checkpoint never \
+            errors because the working tree could not be read.",
+        annotations(read_only_hint = true, open_world_hint = false)
+    )]
+    pub(crate) async fn checkpoint(
+        &self,
+        Parameters(p): Parameters<CheckpointParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let __started = std::time::Instant::now();
+        let __params_json = serde_json::to_value(&p).unwrap_or(serde_json::Value::Null);
+        let __result: Result<CallToolResult, McpError> =
+            super::helpers_compress::run_checkpoint(&self.state, p).await;
+        record_call(
+            &self.state,
+            "checkpoint",
+            &__params_json,
+            __started,
+            &__result,
+        );
+        __result
+    }
+
+    #[tool(
+        description = "Flag redundant reads, repeated queries, and oversized reads from a \
+            JSON-Lines tool-call `log` (one `{\"tool\", \"target\", \"bytes\"}` record per \
+            line; malformed or `tool`-less lines are silently skipped). Three detectors, each \
+            producing a `WasteFinding {kind, target, count, estimated_waste_bytes}`: \
+            `redundant_read` — a `Read` `target` (file path) seen 2+ times, waste = bytes of \
+            every read after the first; `repeated_query` — a search/grep tool (Grep, \
+            workspace_grep, search_symbols, find_references, grep) with an identical `target` \
+            (query string) 2+ times, same waste accounting; `oversized_read` — any single \
+            `Read` with `bytes >= 32768` (suggesting `outline`/`search_symbols` instead of a \
+            full read). Findings are sorted deterministically by `(kind, target)` and capped at \
+            200 (`truncated=true` past the cap; `total_estimated_waste_bytes` still sums every \
+            finding found, before truncation). A finding whose `target` embeds a credential is \
+            dropped entirely. Pure analysis — this tool executes nothing and holds no state \
+            across calls.",
+        annotations(read_only_hint = true, open_world_hint = false)
+    )]
+    pub(crate) async fn detect_waste(
+        &self,
+        Parameters(p): Parameters<DetectWasteParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let __started = std::time::Instant::now();
+        let __params_json = serde_json::to_value(&p).unwrap_or(serde_json::Value::Null);
+        let __result: Result<CallToolResult, McpError> =
+            super::helpers_compress::run_detect_waste(&self.state, p).await;
+        record_call(
+            &self.state,
+            "detect_waste",
             &__params_json,
             __started,
             &__result,

--- a/src/mcp/tools_git.rs
+++ b/src/mcp/tools_git.rs
@@ -18,11 +18,16 @@ use super::types::*;
 impl BasemindServer {
     /// Full-text search over commit history (author / message / body).
     #[tool(
-        description = "Full-text search over git history — author name + email, commit summary, \
-                       and full message body. Tokenized AND match (lowercased, split on \
+        description = "Full-text search over the ENTIRE branch history — author name + email, commit \
+                       summary, and full message body. THIS is the tool for \"what did <author> do\", \
+                       \"find the commit that mentions X\", or \"<author>'s last commit\": it scans \
+                       all commits reachable from HEAD, not a recent window, so it finds matches \
+                       arbitrarily far back (do NOT use `recent_changes` for author/keyword lookups \
+                       — that only sees the newest N). Tokenized AND match (lowercased, split on \
                        non-alphanumeric): every query token must be present. `field` scopes to \
                        `author`, `message`, or `all` (default; `summary`/`body` alias `message`). \
-                       `limit` is page size (default 20, max 100); `cursor` pages results \
+                       Results are newest-first, so the first hit for an author is their most recent \
+                       commit. `limit` is page size (default 20, max 100); `cursor` pages results \
                        (invalidated when HEAD moves). Uses the git-history index when fresh \
                        (searches the full body); otherwise a bounded live fallback over the recent \
                        window, flagged `partial` (author + summary only, no body).",
@@ -90,11 +95,15 @@ impl BasemindServer {
 
     /// Walk HEAD ancestry and return the last N commits.
     #[tool(
-        description = "Last N commits on the current branch, newest first. Each: sha, summary \
-                       (first message line), author, unix timestamp, and — when \
-                       `include_files=true` (default) — the per-file change list vs first parent. \
-                       `limit` is page size (default 20, max 100). `cursor` pages results \
-                       (invalidate when HEAD moves, `cursor_invalidated`). Cached by HEAD sha.",
+        description = "Last N commits on the current branch, newest first — a bounded recency \
+                       window, NOT a search. Each: sha, summary (first message line), author, unix \
+                       timestamp, and — when `include_files=true` (default) — the per-file change \
+                       list vs first parent. `limit` is page size (default 20, max 100), so this \
+                       sees at most the newest ~100 commits: to find a specific author's or \
+                       keyword's commits anywhere in history use `search_git_history` instead \
+                       (an author's last commit may be well outside this window). `cursor` pages \
+                       results (invalidate when HEAD moves, `cursor_invalidated`). Cached by HEAD \
+                       sha.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     pub(crate) async fn recent_changes(

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -300,6 +300,13 @@ pub(super) struct StatusResponse {
     /// unscanned (no-blobs) view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// `true` when a writer (a running `scan`/`rescan`/`watch`) currently holds the store
+    /// lock, so this report was served *without* blocking on the in-progress rebuild. The
+    /// index counts (`file_count`, `languages`) reflect the pre-rebuild state or are omitted;
+    /// `blob_count` is still read fresh from disk. Absent (false) on the common uncontended
+    /// path — status then reflects the fully-committed index.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub rebuild_in_progress: bool,
     pub total_size_bytes: u64,
     pub languages: BTreeMap<String, usize>,
     pub cache_dir: String,

--- a/src/mcp/types_admin.rs
+++ b/src/mcp/types_admin.rs
@@ -36,8 +36,13 @@ pub(super) struct CacheStatsResponse {
     pub other_bytes: u64,
     /// Total blob files on disk (every suffix counts as one file).
     pub blob_count: usize,
-    /// Blob files whose hex stem is referenced by no view — reclaimable by `cache_gc`.
+    /// Blob files whose hex stem is referenced by no view — reclaimable by `cache_gc`. Meaningful
+    /// only when `blob_accounting_ok` is `true`.
     pub orphan_blob_count: usize,
+    /// Whether orphan accounting ran. `false` = a view index was unreadable (stale schema /
+    /// corruption), so `orphan_blob_count` is `0` because it was skipped, not because there are
+    /// none; the size fields remain accurate. Re-scan to restore accounting.
+    pub blob_accounting_ok: bool,
     /// Per-view indexed file count, `(view_name, file_count)`.
     pub per_view_file_count: Vec<(String, usize)>,
     /// Current resident set size (physical RAM) of the process serving this call, in bytes;
@@ -61,6 +66,7 @@ impl From<crate::store_gc::CacheStats> for CacheStatsResponse {
             other_bytes: s.other_bytes,
             blob_count: s.blob_count,
             orphan_blob_count: s.orphan_blob_count,
+            blob_accounting_ok: s.blob_accounting_ok,
             per_view_file_count: s.per_view_file_count,
             rss_bytes: s.rss_bytes,
             peak_rss_bytes: s.peak_rss_bytes,

--- a/src/mcp/types_admin.rs
+++ b/src/mcp/types_admin.rs
@@ -26,12 +26,26 @@ pub(super) struct CacheStatsResponse {
     pub git_cache_bytes: u64,
     /// Byte size of `telemetry.jsonl`.
     pub telemetry_bytes: u64,
+    /// Recursive byte size of the git-history index (`git-history.fjall/`).
+    pub git_history_bytes: u64,
+    /// Recursive byte size of the entire `.basemind/` tree — the ground-truth footprint (matches
+    /// `du`). The component fields break this down; unattributed bytes are in `other_bytes`.
+    pub total_bytes: u64,
+    /// Bytes under `.basemind/` not attributed to a named component (`total_bytes` minus the
+    /// component sum): legacy `index.msgpack`, lock/id/config sidecars, `.gitignore`, etc.
+    pub other_bytes: u64,
     /// Total blob files on disk (every suffix counts as one file).
     pub blob_count: usize,
     /// Blob files whose hex stem is referenced by no view — reclaimable by `cache_gc`.
     pub orphan_blob_count: usize,
     /// Per-view indexed file count, `(view_name, file_count)`.
     pub per_view_file_count: Vec<(String, usize)>,
+    /// Current resident set size (physical RAM) of the process serving this call, in bytes;
+    /// `null` when unreadable. Inside `basemind serve` this is the live MCP server process.
+    pub rss_bytes: Option<u64>,
+    /// Peak resident set size of the serving process over its lifetime, in bytes; `null` when
+    /// unreadable.
+    pub peak_rss_bytes: Option<u64>,
 }
 
 impl From<crate::store_gc::CacheStats> for CacheStatsResponse {
@@ -42,9 +56,14 @@ impl From<crate::store_gc::CacheStats> for CacheStatsResponse {
             lance_bytes: s.lance_bytes,
             git_cache_bytes: s.git_cache_bytes,
             telemetry_bytes: s.telemetry_bytes,
+            git_history_bytes: s.git_history_bytes,
+            total_bytes: s.total_bytes,
+            other_bytes: s.other_bytes,
             blob_count: s.blob_count,
             orphan_blob_count: s.orphan_blob_count,
             per_view_file_count: s.per_view_file_count,
+            rss_bytes: s.rss_bytes,
+            peak_rss_bytes: s.peak_rss_bytes,
         }
     }
 }

--- a/src/mcp/types_compress.rs
+++ b/src/mcp/types_compress.rs
@@ -114,6 +114,36 @@ pub(super) struct CompressResponse {
     pub tokens_note: String,
 }
 
+/// Parameters for the `delta` MCP tool.
+///
+/// Both sides are supplied inline as strings (unlike the CLI, which reads `old` from a file
+/// and `new` from stdin): the caller passes whatever OLD content it previously saw and the
+/// NEW content it just read.
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct DeltaParams {
+    /// Previously seen content.
+    pub old: String,
+    /// Current content to diff against `old`.
+    pub new: String,
+}
+
+/// Parameters for the `checkpoint` MCP tool.
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct CheckpointParams {
+    /// Session text (a transcript chunk or concatenated tool output) to extract a
+    /// checkpoint from. The changed-file list is NOT derived from this text — it comes
+    /// from this server's git working tree.
+    pub text: String,
+}
+
+/// Parameters for the `detect_waste` MCP tool.
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct DetectWasteParams {
+    /// JSON-Lines tool-call log, one `{"tool", "target", "bytes"}` record per line.
+    /// Malformed or `tool`-less lines are silently skipped.
+    pub log: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use ahash::AHashMap;
-use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -165,6 +164,12 @@ fn lock_contention_message(path: &Path, holder: &Option<LockMeta>) -> String {
 pub const LOCK_CONTENTION_HELP: &str = "the basemind index is locked by another process \
 (likely the MCP server). If an editor/plugin is serving this repo, use its `rescan` tool \
 to refresh the index, or stop that server before running `basemind scan`.";
+
+// The lock *behavior* lives in `store_lock.rs` (extracted to keep this file under the module-size
+// cap); the lock *types* above stay here. Re-export the entry points so callers keep importing
+// them from `crate::store`.
+pub use crate::store_lock::{WriterProbe, probe_writer_lock};
+pub(crate) use crate::store_lock::{acquire_lock, acquire_lock_as, writer_lock_is_held};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Index {
@@ -660,136 +665,6 @@ pub(crate) fn open_index_with_retry(view_dir: &Path) -> Result<IndexDb, IndexErr
     }
 }
 
-/// Best-effort probe: does a live writer currently hold the exclusive `.basemind/.lock`?
-///
-/// A read-only consumer calls this before deciding whether to even attempt opening the
-/// single-holder Fjall index. If a writer holds the lock, the reader's open cannot succeed anyway
-/// (Fjall is one-holder) — and, worse, the reader's *transient* acquisition attempt can knock the
-/// rightful writer into read-only (the multi-session writer-downgrade race). So when a writer is
-/// live the reader skips Fjall entirely and serves from the concurrently-readable blobs
-/// (`index_db = None`). Returns `false` when no lock file exists or the probe can't run — the
-/// caller then falls through to attempting the open (correct for the no-writer CLI case).
-fn writer_lock_is_held(basemind_dir: &Path) -> bool {
-    let path = basemind_dir.join(LOCK_FILE);
-    let Ok(file) = OpenOptions::new().read(true).write(true).open(&path) else {
-        // No lock file (never scanned) or unopenable — assume no live writer.
-        return false;
-    };
-    match file.try_lock_shared() {
-        Ok(()) => {
-            // No exclusive holder. Release our shared probe immediately so we never block a
-            // writer that starts right after this check.
-            let _ = FileExt::unlock(&file);
-            false
-        }
-        // Contention (a writer holds it exclusive) or any probe error → treat as "writer live"
-        // and serve from blobs. Skipping Fjall is always a safe degradation.
-        Err(_) => true,
-    }
-}
-
-/// Non-blocking classification of the store write lock, for the CLI write path to pre-detect a
-/// live `serve` / `watch` *before* colliding with it. The reactive [`StoreError::Locked`] path
-/// remains the safety net for the race between this probe and the actual acquire.
-#[derive(Debug)]
-pub enum WriterProbe {
-    /// No live writer holds the lock — safe to open for write.
-    Free,
-    /// A writer holds the lock. `holder` names it from the `.lock.meta` sidecar when readable;
-    /// `None` when the sidecar is missing/corrupt (the holder is live but unidentified).
-    Held { holder: Option<LockMeta> },
-}
-
-/// Probe the store write lock without blocking or acquiring it. See [`WriterProbe`]. A `Free`
-/// result is advisory only — a writer may start between this call and a subsequent acquire, so
-/// callers must still handle [`StoreError::Locked`].
-pub fn probe_writer_lock(basemind_dir: &Path) -> WriterProbe {
-    if writer_lock_is_held(basemind_dir) {
-        WriterProbe::Held {
-            holder: read_lock_meta(basemind_dir),
-        }
-    } else {
-        WriterProbe::Free
-    }
-}
-
-pub(crate) fn acquire_lock(basemind_dir: &Path) -> Result<File, StoreError> {
-    acquire_lock_as(basemind_dir, LockHolder::Maintenance)
-}
-
-/// Acquire the store lock, recording `holder` in the `.lock.meta` sidecar on success and
-/// reading the *existing* holder's sidecar on contention so the error names the live holder.
-pub(crate) fn acquire_lock_as(basemind_dir: &Path, holder: LockHolder) -> Result<File, StoreError> {
-    let path = basemind_dir.join(LOCK_FILE);
-    let file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&path)
-        .map_err(|source| StoreError::Io {
-            path: path.clone(),
-            source,
-        })?;
-    // A Store dropped microseconds earlier in this process (or a just-exited
-    // holder) can leave the advisory `flock` briefly un-released — macOS in
-    // particular does not always release it before the next acquire observes it.
-    // Retry with a short backoff so a sequential open → close → open never races;
-    // only a lock genuinely held for the whole window (e.g. `basemind watch`)
-    // surfaces as `Locked`.
-    const LOCK_ATTEMPTS: u32 = 25;
-    const LOCK_BACKOFF: std::time::Duration = std::time::Duration::from_millis(20);
-    for attempt in 0..LOCK_ATTEMPTS {
-        match file.try_lock_exclusive() {
-            Ok(()) => {
-                // Won the lock — record who we are. Best-effort; a write failure here must
-                // not fail an otherwise-successful acquisition (the sidecar is advisory).
-                write_lock_meta(basemind_dir, holder);
-                return Ok(file);
-            }
-            Err(_) if attempt + 1 < LOCK_ATTEMPTS => std::thread::sleep(LOCK_BACKOFF),
-            Err(_) => {
-                return Err(StoreError::Locked {
-                    holder: read_lock_meta(basemind_dir),
-                    path,
-                });
-            }
-        }
-    }
-    unreachable!("loop returns on the final attempt")
-}
-
-/// Write the `.lock.meta` sidecar naming the current holder. Best-effort and atomic
-/// (tmp + rename): the lock itself is already held when this runs, so a failure here only
-/// degrades the *next* contender's error message to the generic guess — never a correctness
-/// issue. Errors are swallowed deliberately.
-fn write_lock_meta(basemind_dir: &Path, holder: LockHolder) {
-    let acquired_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let meta = LockMeta {
-        command: holder.command().to_string(),
-        pid: std::process::id(),
-        acquired_unix,
-    };
-    let Ok(bytes) = serde_json::to_vec(&meta) else {
-        return;
-    };
-    let final_path = basemind_dir.join(LOCK_META_FILE);
-    let tmp_path = basemind_dir.join(format!("{LOCK_META_FILE}.{}.tmp", std::process::id()));
-    if std::fs::write(&tmp_path, &bytes).is_ok() {
-        let _ = std::fs::rename(&tmp_path, &final_path);
-    }
-}
-
-/// Read the `.lock.meta` sidecar to identify the live holder. `None` when it is absent or
-/// unparsable, so the caller falls back to the generic lock message.
-fn read_lock_meta(basemind_dir: &Path) -> Option<LockMeta> {
-    let bytes = std::fs::read(basemind_dir.join(LOCK_META_FILE)).ok()?;
-    serde_json::from_slice(&bytes).ok()
-}
-
 fn check_schema(found: u16) -> Result<(), StoreError> {
     if found == SCHEMA_VER {
         Ok(())
@@ -992,34 +867,5 @@ mod tests {
             expected: 2,
         };
         assert!(!err.is_lock_contention());
-    }
-
-    #[test]
-    fn probe_writer_lock_reports_free_when_unlocked() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(
-            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
-            "an untouched .basemind dir has no live writer"
-        );
-    }
-
-    #[test]
-    fn probe_writer_lock_names_the_live_holder() {
-        // Pre-flight probe underpinning the CLI double-run guidance: while a writer holds the
-        // exclusive lock, the probe must report `Held` and surface the `.lock.meta` holder so
-        // `scan`/`rescan` can name the running `serve` instead of colliding with it.
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let guard = acquire_lock_as(tmp.path(), LockHolder::Serve).expect("acquire exclusive lock");
-        match probe_writer_lock(tmp.path()) {
-            WriterProbe::Held { holder: Some(meta) } => {
-                assert_eq!(meta.command, "basemind serve", "sidecar names the holder")
-            }
-            other => panic!("expected Held with named holder, got {other:?}"),
-        }
-        drop(guard);
-        assert!(
-            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
-            "lock is free once the holder drops"
-        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -688,6 +688,31 @@ fn writer_lock_is_held(basemind_dir: &Path) -> bool {
     }
 }
 
+/// Non-blocking classification of the store write lock, for the CLI write path to pre-detect a
+/// live `serve` / `watch` *before* colliding with it. The reactive [`StoreError::Locked`] path
+/// remains the safety net for the race between this probe and the actual acquire.
+#[derive(Debug)]
+pub enum WriterProbe {
+    /// No live writer holds the lock — safe to open for write.
+    Free,
+    /// A writer holds the lock. `holder` names it from the `.lock.meta` sidecar when readable;
+    /// `None` when the sidecar is missing/corrupt (the holder is live but unidentified).
+    Held { holder: Option<LockMeta> },
+}
+
+/// Probe the store write lock without blocking or acquiring it. See [`WriterProbe`]. A `Free`
+/// result is advisory only — a writer may start between this call and a subsequent acquire, so
+/// callers must still handle [`StoreError::Locked`].
+pub fn probe_writer_lock(basemind_dir: &Path) -> WriterProbe {
+    if writer_lock_is_held(basemind_dir) {
+        WriterProbe::Held {
+            holder: read_lock_meta(basemind_dir),
+        }
+    } else {
+        WriterProbe::Free
+    }
+}
+
 pub(crate) fn acquire_lock(basemind_dir: &Path) -> Result<File, StoreError> {
     acquire_lock_as(basemind_dir, LockHolder::Maintenance)
 }
@@ -967,5 +992,34 @@ mod tests {
             expected: 2,
         };
         assert!(!err.is_lock_contention());
+    }
+
+    #[test]
+    fn probe_writer_lock_reports_free_when_unlocked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
+            "an untouched .basemind dir has no live writer"
+        );
+    }
+
+    #[test]
+    fn probe_writer_lock_names_the_live_holder() {
+        // Pre-flight probe underpinning the CLI double-run guidance: while a writer holds the
+        // exclusive lock, the probe must report `Held` and surface the `.lock.meta` holder so
+        // `scan`/`rescan` can name the running `serve` instead of colliding with it.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let guard = acquire_lock_as(tmp.path(), LockHolder::Serve).expect("acquire exclusive lock");
+        match probe_writer_lock(tmp.path()) {
+            WriterProbe::Held { holder: Some(meta) } => {
+                assert_eq!(meta.command, "basemind serve", "sidecar names the holder")
+            }
+            other => panic!("expected Held with named holder, got {other:?}"),
+        }
+        drop(guard);
+        assert!(
+            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
+            "lock is free once the holder drops"
+        );
     }
 }

--- a/src/store_gc.rs
+++ b/src/store_gc.rs
@@ -142,12 +142,33 @@ pub struct CacheStats {
     pub git_cache_bytes: u64,
     /// Byte size of `telemetry.jsonl`.
     pub telemetry_bytes: u64,
+    /// Recursive byte size of the precomputed git-history index (`git-history.fjall/`). Added in
+    /// 0.16: before that this directory (a sibling of `views/`, often hundreds of MB on a
+    /// deep-history repo) was omitted, so the reported total undercounted `du` — the bug this
+    /// field fixes.
+    pub git_history_bytes: u64,
+    /// Recursive byte size of the **entire** `.basemind/` tree. This is the ground-truth total
+    /// (it matches `du`); the per-component fields are a breakdown of it, and any bytes not
+    /// attributed to a named component land in [`Self::other_bytes`]. Computed from the whole
+    /// tree so a future uncounted directory can never silently shrink the reported footprint.
+    pub total_bytes: u64,
+    /// Bytes under `.basemind/` not attributed to any named component (`total_bytes` minus the
+    /// sum of the component fields): the legacy top-level `index.msgpack`, lock/id/config
+    /// sidecars, `.gitignore`, and anything a future version adds before it gets its own field.
+    pub other_bytes: u64,
     /// Total blob files on disk (every suffix counts as one file).
     pub blob_count: usize,
     /// Blob files whose hex stem is referenced by no view — reclaimable by [`run_gc`].
     pub orphan_blob_count: usize,
     /// Per-view indexed file count, keyed by view name. Empty entries are still listed.
     pub per_view_file_count: Vec<(String, usize)>,
+    /// Current resident set size (physical RAM) of the process answering this call, in bytes.
+    /// `None` when unreadable on this platform. Inside `basemind serve` this is the live MCP
+    /// server; from the one-shot CLI it is that transient process. See [`crate::sysres`].
+    pub rss_bytes: Option<u64>,
+    /// Peak resident set size of the reporting process over its lifetime, in bytes; `None` when
+    /// unreadable. See [`crate::sysres`].
+    pub peak_rss_bytes: Option<u64>,
 }
 
 /// Enumerate every view's `index.msgpack` and union the hex content hashes it references.
@@ -355,15 +376,40 @@ pub fn cache_stats(basemind_dir: &Path) -> Result<CacheStats, GcError> {
         }
     }
 
+    let blobs_bytes = dir_size(&blobs_dir)?;
+    let views_bytes = dir_size(&basemind_dir.join(VIEWS_DIR))?;
+    let lance_bytes = dir_size(&basemind_dir.join("lance"))?;
+    let git_cache_bytes = dir_size(&basemind_dir.join(crate::git_cache::GIT_CACHE_DIR))?;
+    let telemetry_bytes = file_size(&basemind_dir.join(TELEMETRY_FILENAME))?;
+    let git_history_bytes = dir_size(&basemind_dir.join(crate::git_history::GIT_HISTORY_DIR))?;
+
+    // Ground-truth footprint: size the whole tree, then derive `other` as the remainder so the
+    // breakdown always reconciles to the total and no directory can go uncounted.
+    let total_bytes = dir_size(basemind_dir)?;
+    let accounted = blobs_bytes
+        + views_bytes
+        + lance_bytes
+        + git_cache_bytes
+        + telemetry_bytes
+        + git_history_bytes;
+    let other_bytes = total_bytes.saturating_sub(accounted);
+
+    let rss = crate::sysres::sample();
+
     Ok(CacheStats {
-        blobs_bytes: dir_size(&blobs_dir)?,
-        views_bytes: dir_size(&basemind_dir.join(VIEWS_DIR))?,
-        lance_bytes: dir_size(&basemind_dir.join("lance"))?,
-        git_cache_bytes: dir_size(&basemind_dir.join(crate::git_cache::GIT_CACHE_DIR))?,
-        telemetry_bytes: file_size(&basemind_dir.join(TELEMETRY_FILENAME))?,
+        blobs_bytes,
+        views_bytes,
+        lance_bytes,
+        git_cache_bytes,
+        telemetry_bytes,
+        git_history_bytes,
+        total_bytes,
+        other_bytes,
         blob_count,
         orphan_blob_count,
         per_view_file_count: per_view_file_count(basemind_dir)?,
+        rss_bytes: rss.current_bytes,
+        peak_rss_bytes: rss.peak_bytes,
     })
 }
 
@@ -450,26 +496,48 @@ fn read_dir(dir: &Path) -> Result<std::fs::ReadDir, GcError> {
     })
 }
 
-/// Byte size of a single file, or `0` if it is absent.
+/// On-disk (allocated) size of a filesystem entry, matching what `du` reports.
+///
+/// Uses the allocated block count (`blocks × 512`) on Unix rather than the apparent length
+/// (`metadata().len()`). This matters because Fjall keeps **sparse** journal files: their apparent
+/// length can be tens of MB while only a few hundred KB of blocks are actually allocated. Summing
+/// apparent lengths over-reported the footprint many-fold (e.g. a 9.6 MB `.basemind/` read as
+/// ~132 MB); block size is the ground truth that reconciles to `du`. On non-Unix we fall back to
+/// the apparent length (no portable block API).
+#[cfg(unix)]
+fn on_disk_size(meta: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    meta.blocks().saturating_mul(512)
+}
+
+#[cfg(not(unix))]
+fn on_disk_size(meta: &std::fs::Metadata) -> u64 {
+    meta.len()
+}
+
+/// On-disk size of a single file, or `0` if it is absent.
 fn file_size(path: &Path) -> Result<u64, GcError> {
     if !path.exists() {
         return Ok(0);
     }
-    Ok(std::fs::metadata(path)
-        .map_err(|source| GcError::Io {
-            path: path.to_path_buf(),
-            source,
-        })?
-        .len())
+    let meta = std::fs::symlink_metadata(path).map_err(|source| GcError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(on_disk_size(&meta))
 }
 
-/// Recursive byte size of a directory tree. Returns `0` for a missing directory; follows no
-/// symlinks (counts the link entry's own size only, like `du` without `-L`).
+/// Recursive on-disk size of a directory tree, matching `du`: counts the allocated blocks of every
+/// entry — the directory's own inode blocks included — via [`on_disk_size`]. Returns `0` for a
+/// missing directory; follows no symlinks (counts the link entry itself, like `du` without `-L`).
 fn dir_size(dir: &Path) -> Result<u64, GcError> {
     if !dir.exists() {
         return Ok(0);
     }
-    let mut total = 0u64;
+    // The directory's own allocation (`du` counts it too).
+    let mut total = std::fs::symlink_metadata(dir)
+        .map(|m| on_disk_size(&m))
+        .unwrap_or(0);
     for entry in read_dir(dir)? {
         let entry = entry.map_err(|source| GcError::Io {
             path: dir.to_path_buf(),
@@ -481,9 +549,10 @@ fn dir_size(dir: &Path) -> Result<u64, GcError> {
             source,
         })?;
         if meta.is_dir() {
+            // Recursion counts the subdirectory's own blocks + its contents.
             total += dir_size(&path)?;
         } else {
-            total += meta.len();
+            total += on_disk_size(&meta);
         }
     }
     Ok(total)
@@ -553,6 +622,57 @@ mod tests {
             orphan_stem,
             orphan_len,
         }
+    }
+
+    #[test]
+    fn cache_stats_counts_git_history_and_reconciles_total() {
+        // Regression for the 0.15 disk-undercount bug: `git-history.fjall/` (a sibling of
+        // `views/`) was never summed, so the reported total fell short of `du`. Assert it is now
+        // counted and that the breakdown reconciles exactly to the whole-tree total.
+        let fx = build_fixture();
+
+        // A git-history index directory with a known payload …
+        let gh_dir = fx.basemind_dir.join(crate::git_history::GIT_HISTORY_DIR);
+        fs::create_dir_all(&gh_dir).expect("mk git-history");
+        let gh_payload = b"git-history-index-bytes-XXXXXXXX";
+        fs::write(gh_dir.join("commits.fjall"), gh_payload).expect("write gh blob");
+
+        // … and a stray top-level file that belongs to no named component (→ `other_bytes`).
+        let stray = b"lockmeta";
+        fs::write(fx.basemind_dir.join(".lock.meta"), stray).expect("write stray");
+
+        let stats = cache_stats(&fx.basemind_dir).expect("cache_stats");
+
+        // Block-rounded (allocated) sizing, so assert coverage rather than exact byte counts: the
+        // git-history directory is now counted (was silently omitted before 0.16).
+        assert!(
+            stats.git_history_bytes >= gh_payload.len() as u64,
+            "git-history.fjall/ must be counted (got {})",
+            stats.git_history_bytes
+        );
+        assert!(
+            stats.other_bytes >= stray.len() as u64,
+            "the unattributed stray file lands in other_bytes (got {})",
+            stats.other_bytes
+        );
+
+        // The whole-tree total is ground truth, and the breakdown reconciles to it exactly.
+        assert_eq!(
+            stats.total_bytes,
+            dir_size(&fx.basemind_dir).expect("dir_size"),
+            "total_bytes is the whole .basemind/ tree"
+        );
+        let component_sum = stats.blobs_bytes
+            + stats.views_bytes
+            + stats.lance_bytes
+            + stats.git_cache_bytes
+            + stats.telemetry_bytes
+            + stats.git_history_bytes;
+        assert_eq!(
+            stats.total_bytes,
+            component_sum + stats.other_bytes,
+            "components + other must reconcile to total"
+        );
     }
 
     #[test]

--- a/src/store_gc.rs
+++ b/src/store_gc.rs
@@ -158,8 +158,13 @@ pub struct CacheStats {
     pub other_bytes: u64,
     /// Total blob files on disk (every suffix counts as one file).
     pub blob_count: usize,
-    /// Blob files whose hex stem is referenced by no view — reclaimable by [`run_gc`].
+    /// Blob files whose hex stem is referenced by no view — reclaimable by [`run_gc`]. Meaningful
+    /// only when [`Self::blob_accounting_ok`] is `true`; `0` otherwise (not computed).
     pub orphan_blob_count: usize,
+    /// Whether orphan accounting ran. `false` means a view index couldn't be read (stale schema
+    /// or corruption), so [`Self::orphan_blob_count`] is `0` because it was skipped, NOT because
+    /// there are no orphans — the size fields are still accurate. Re-scan to restore accounting.
+    pub blob_accounting_ok: bool,
     /// Per-view indexed file count, keyed by view name. Empty entries are still listed.
     pub per_view_file_count: Vec<(String, usize)>,
     /// Current resident set size (physical RAM) of the process answering this call, in bytes.
@@ -348,7 +353,23 @@ pub fn clear_single_view(basemind_dir: &Path, name: &str) -> Result<(), GcError>
 /// count reuses [`collect_referenced_hashes`] but never deletes.
 pub fn cache_stats(basemind_dir: &Path) -> Result<CacheStats, GcError> {
     let blobs_dir = basemind_dir.join(BLOBS_DIR);
-    let referenced = collect_referenced_hashes(basemind_dir)?;
+    // cache_stats is read-only and never deletes, so — unlike `cache_gc` — it must NOT hard-fail
+    // when a view index can't be read (e.g. a schema-mismatched `.basemind/` from an older binary
+    // that hasn't been re-scanned). The disk/RAM footprint is exactly what an operator asking
+    // "how much does this consume" needs, and it requires no index. So degrade: report sizes
+    // regardless, and mark orphan accounting unavailable when the live set can't be determined.
+    let referenced = match collect_referenced_hashes(basemind_dir) {
+        Ok(set) => Some(set),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "cache_stats: could not read a view index (stale schema or corrupt); \
+                 reporting sizes only, orphan accounting skipped"
+            );
+            None
+        }
+    };
+    let blob_accounting_ok = referenced.is_some();
 
     let mut blob_count = 0usize;
     let mut orphan_blob_count = 0usize;
@@ -370,7 +391,11 @@ pub fn cache_stats(basemind_dir: &Path) -> Result<CacheStats, GcError> {
                 continue;
             };
             blob_count += 1;
-            if !referenced.contains(stem) {
+            // Only classify orphans when the live reference set is known; otherwise leave the
+            // count at 0 and let `blob_accounting_ok = false` disclose it wasn't computed.
+            if let Some(referenced) = &referenced
+                && !referenced.contains(stem)
+            {
                 orphan_blob_count += 1;
             }
         }
@@ -407,6 +432,7 @@ pub fn cache_stats(basemind_dir: &Path) -> Result<CacheStats, GcError> {
         other_bytes,
         blob_count,
         orphan_blob_count,
+        blob_accounting_ok,
         per_view_file_count: per_view_file_count(basemind_dir)?,
         rss_bytes: rss.current_bytes,
         peak_rss_bytes: rss.peak_bytes,
@@ -672,6 +698,45 @@ mod tests {
             stats.total_bytes,
             component_sum + stats.other_bytes,
             "components + other must reconcile to total"
+        );
+    }
+
+    #[test]
+    fn cache_stats_degrades_when_index_unreadable() {
+        // A corrupt/unreadable view index (e.g. an older-schema `.basemind/` not yet re-scanned)
+        // must not sink the whole call: sizes are still reported, orphan accounting is skipped,
+        // and `blob_accounting_ok` discloses that. (GC, which deletes, still hard-fails — asserted
+        // separately by the collect/gc tests.)
+        let fx = build_fixture();
+        let working = fx.basemind_dir.join(VIEWS_DIR).join("working");
+        // Overwrite the valid index with bytes rmp-serde can't decode.
+        fs::write(working.join(INDEX_FILE), b"\xff\xff not-msgpack \x00").expect("corrupt index");
+
+        // collect_referenced_hashes (the GC safety path) still errors …
+        assert!(
+            collect_referenced_hashes(&fx.basemind_dir).is_err(),
+            "an unreadable index must fail the delete-path safety check"
+        );
+
+        // … but read-only stats degrade gracefully.
+        let stats = cache_stats(&fx.basemind_dir).expect("cache_stats must not hard-fail");
+        assert!(
+            !stats.blob_accounting_ok,
+            "orphan accounting must be flagged unavailable"
+        );
+        assert_eq!(
+            stats.orphan_blob_count, 0,
+            "orphan count is 0 (skipped), not a real zero"
+        );
+        assert!(
+            stats.blob_count >= 2,
+            "blob files are still counted by size walk"
+        );
+        assert!(stats.total_bytes > 0, "sizes are still reported");
+        assert_eq!(
+            stats.total_bytes,
+            dir_size(&fx.basemind_dir).expect("dir_size"),
+            "total still reconciles to the tree"
         );
     }
 

--- a/src/store_lock.rs
+++ b/src/store_lock.rs
@@ -1,0 +1,178 @@
+//! Store write-lock machinery: the advisory `.basemind/.lock` flock, the `.lock.meta` holder
+//! sidecar, acquisition with retry, and the non-blocking writer probe.
+//!
+//! Split out of `store.rs` to keep that file under the 1000-line module cap. The lock *types*
+//! ([`LockHolder`] / [`LockMeta`]) and [`StoreError`] stay in `store.rs`; this module holds the
+//! behavior over them. `store.rs` re-exports the public entry points (`probe_writer_lock`,
+//! `acquire_lock*`, …) so callers keep importing them from `crate::store`.
+
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+
+use fs2::FileExt;
+
+use crate::store::{LOCK_FILE, LOCK_META_FILE, LockHolder, LockMeta, StoreError};
+
+/// Best-effort probe: does a live writer currently hold the exclusive `.basemind/.lock`?
+///
+/// A read-only consumer calls this before deciding whether to even attempt opening the
+/// single-holder Fjall index. If a writer holds the lock, the reader's open cannot succeed anyway
+/// (Fjall is one-holder) — and, worse, the reader's *transient* acquisition attempt can knock the
+/// rightful writer into read-only (the multi-session writer-downgrade race). So when a writer is
+/// live the reader skips Fjall entirely and serves from the concurrently-readable blobs
+/// (`index_db = None`). Returns `false` when no lock file exists or the probe can't run — the
+/// caller then falls through to attempting the open (correct for the no-writer CLI case).
+pub(crate) fn writer_lock_is_held(basemind_dir: &Path) -> bool {
+    let path = basemind_dir.join(LOCK_FILE);
+    let Ok(file) = OpenOptions::new().read(true).write(true).open(&path) else {
+        // No lock file (never scanned) or unopenable — assume no live writer.
+        return false;
+    };
+    match file.try_lock_shared() {
+        Ok(()) => {
+            // No exclusive holder. Release our shared probe immediately so we never block a
+            // writer that starts right after this check.
+            let _ = FileExt::unlock(&file);
+            false
+        }
+        // Contention (a writer holds it exclusive) or any probe error → treat as "writer live"
+        // and serve from blobs. Skipping Fjall is always a safe degradation.
+        Err(_) => true,
+    }
+}
+
+/// Non-blocking classification of the store write lock, for the CLI write path to pre-detect a
+/// live `serve` / `watch` *before* colliding with it. The reactive [`StoreError::Locked`] path
+/// remains the safety net for the race between this probe and the actual acquire.
+#[derive(Debug)]
+pub enum WriterProbe {
+    /// No live writer holds the lock — safe to open for write.
+    Free,
+    /// A writer holds the lock. `holder` names it from the `.lock.meta` sidecar when readable;
+    /// `None` when the sidecar is missing/corrupt (the holder is live but unidentified).
+    Held { holder: Option<LockMeta> },
+}
+
+/// Probe the store write lock without blocking or acquiring it. See [`WriterProbe`]. A `Free`
+/// result is advisory only — a writer may start between this call and a subsequent acquire, so
+/// callers must still handle [`StoreError::Locked`].
+pub fn probe_writer_lock(basemind_dir: &Path) -> WriterProbe {
+    if writer_lock_is_held(basemind_dir) {
+        WriterProbe::Held {
+            holder: read_lock_meta(basemind_dir),
+        }
+    } else {
+        WriterProbe::Free
+    }
+}
+
+pub(crate) fn acquire_lock(basemind_dir: &Path) -> Result<File, StoreError> {
+    acquire_lock_as(basemind_dir, LockHolder::Maintenance)
+}
+
+/// Acquire the store lock, recording `holder` in the `.lock.meta` sidecar on success and
+/// reading the *existing* holder's sidecar on contention so the error names the live holder.
+pub(crate) fn acquire_lock_as(basemind_dir: &Path, holder: LockHolder) -> Result<File, StoreError> {
+    let path = basemind_dir.join(LOCK_FILE);
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .map_err(|source| StoreError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    // A Store dropped microseconds earlier in this process (or a just-exited
+    // holder) can leave the advisory `flock` briefly un-released — macOS in
+    // particular does not always release it before the next acquire observes it.
+    // Retry with a short backoff so a sequential open → close → open never races;
+    // only a lock genuinely held for the whole window (e.g. `basemind watch`)
+    // surfaces as `Locked`.
+    const LOCK_ATTEMPTS: u32 = 25;
+    const LOCK_BACKOFF: std::time::Duration = std::time::Duration::from_millis(20);
+    for attempt in 0..LOCK_ATTEMPTS {
+        match file.try_lock_exclusive() {
+            Ok(()) => {
+                // Won the lock — record who we are. Best-effort; a write failure here must
+                // not fail an otherwise-successful acquisition (the sidecar is advisory).
+                write_lock_meta(basemind_dir, holder);
+                return Ok(file);
+            }
+            Err(_) if attempt + 1 < LOCK_ATTEMPTS => std::thread::sleep(LOCK_BACKOFF),
+            Err(_) => {
+                return Err(StoreError::Locked {
+                    holder: read_lock_meta(basemind_dir),
+                    path,
+                });
+            }
+        }
+    }
+    unreachable!("loop returns on the final attempt")
+}
+
+/// Write the `.lock.meta` sidecar naming the current holder. Best-effort and atomic
+/// (tmp + rename): the lock itself is already held when this runs, so a failure here only
+/// degrades the *next* contender's error message to the generic guess — never a correctness
+/// issue. Errors are swallowed deliberately.
+fn write_lock_meta(basemind_dir: &Path, holder: LockHolder) {
+    let acquired_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let meta = LockMeta {
+        command: holder.command().to_string(),
+        pid: std::process::id(),
+        acquired_unix,
+    };
+    let Ok(bytes) = serde_json::to_vec(&meta) else {
+        return;
+    };
+    let final_path = basemind_dir.join(LOCK_META_FILE);
+    let tmp_path = basemind_dir.join(format!("{LOCK_META_FILE}.{}.tmp", std::process::id()));
+    if std::fs::write(&tmp_path, &bytes).is_ok() {
+        let _ = std::fs::rename(&tmp_path, &final_path);
+    }
+}
+
+/// Read the `.lock.meta` sidecar to identify the live holder. `None` when it is absent or
+/// unparsable, so the caller falls back to the generic lock message.
+fn read_lock_meta(basemind_dir: &Path) -> Option<LockMeta> {
+    let bytes = std::fs::read(basemind_dir.join(LOCK_META_FILE)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_writer_lock_reports_free_when_unlocked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(
+            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
+            "an untouched .basemind dir has no live writer"
+        );
+    }
+
+    #[test]
+    fn probe_writer_lock_names_the_live_holder() {
+        // Pre-flight probe underpinning the CLI double-run guidance: while a writer holds the
+        // exclusive lock, the probe must report `Held` and surface the `.lock.meta` holder so
+        // `scan`/`rescan` can name the running `serve` instead of colliding with it.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let guard = acquire_lock_as(tmp.path(), LockHolder::Serve).expect("acquire exclusive lock");
+        match probe_writer_lock(tmp.path()) {
+            WriterProbe::Held { holder: Some(meta) } => {
+                assert_eq!(meta.command, "basemind serve", "sidecar names the holder")
+            }
+            other => panic!("expected Held with named holder, got {other:?}"),
+        }
+        drop(guard);
+        assert!(
+            matches!(probe_writer_lock(tmp.path()), WriterProbe::Free),
+            "lock is free once the holder drops"
+        );
+    }
+}

--- a/src/sysres.rs
+++ b/src/sysres.rs
@@ -1,0 +1,129 @@
+//! System-resource sampling for the *reporting* process — current and peak resident set size
+//! (RSS), in bytes.
+//!
+//! basemind historically reported on-disk footprint only; the `cache_stats` surface now also
+//! answers "how much RAM does it consume". The number is the RSS of whatever process calls
+//! [`sample`]: inside `basemind serve` that is the long-lived MCP server (the value the user
+//! cares about); from the one-shot `basemind cache stats` CLI it is that short-lived process.
+//! Both are honest self-measurements, so the field is labelled "this process".
+//!
+//! Platform sources:
+//! - **macOS**: mach `task_info(MACH_TASK_BASIC_INFO)` for current RSS; `getrusage` `ru_maxrss`
+//!   (bytes on Darwin) for peak.
+//! - **Linux**: `/proc/self/statm` (resident pages × page size) for current; `getrusage`
+//!   `ru_maxrss` (kilobytes) for peak.
+//! - **Other platforms**: `None` (best-effort; callers render "unavailable").
+
+/// Resident-set-size sample for the current process, in bytes. Each field is `None` when the
+/// value cannot be read on this platform or the syscall failed — callers treat `None` as
+/// "unavailable" rather than zero.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RssSample {
+    /// Current resident set size (physical RAM backing the process), in bytes.
+    pub current_bytes: Option<u64>,
+    /// Peak resident set size observed over the process lifetime, in bytes.
+    pub peak_bytes: Option<u64>,
+}
+
+/// Sample the current process's RSS. Cheap (one syscall per field); safe to call per request.
+pub fn sample() -> RssSample {
+    RssSample {
+        current_bytes: current_rss(),
+        peak_bytes: peak_rss(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn current_rss() -> Option<u64> {
+    use std::mem;
+
+    use mach2::kern_return::KERN_SUCCESS;
+    use mach2::message::mach_msg_type_number_t;
+    use mach2::task::task_info;
+    use mach2::task_info::{MACH_TASK_BASIC_INFO, mach_task_basic_info, task_info_t};
+    use mach2::traps::mach_task_self;
+
+    // SAFETY: `task_info` with `MACH_TASK_BASIC_INFO` fills a `mach_task_basic_info` struct. We
+    // pass a zeroed buffer of exactly that type and its element count in 32-bit words, and read
+    // `resident_size` only when the kernel returns `KERN_SUCCESS`.
+    unsafe {
+        let mut info = mem::zeroed::<mach_task_basic_info>();
+        let mut count = (mem::size_of::<mach_task_basic_info>() / mem::size_of::<u32>())
+            as mach_msg_type_number_t;
+        let kr = task_info(
+            mach_task_self(),
+            MACH_TASK_BASIC_INFO,
+            (&mut info as *mut mach_task_basic_info).cast::<i32>() as task_info_t,
+            &mut count,
+        );
+        if kr == KERN_SUCCESS {
+            Some(info.resident_size)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss() -> Option<u64> {
+    // `/proc/self/statm` field 2 (0-indexed 1) is the resident page count.
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    // SAFETY: `sysconf` is a pure query with no memory effects; a non-positive result means the
+    // limit is indeterminate, so we fall back to the near-universal 4 KiB page.
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let page = if page > 0 { page as u64 } else { 4096 };
+    Some(resident_pages.saturating_mul(page))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn current_rss() -> Option<u64> {
+    None
+}
+
+#[cfg(unix)]
+fn peak_rss() -> Option<u64> {
+    use std::mem;
+    // SAFETY: `getrusage` writes a full `rusage` into the zeroed buffer; we read `ru_maxrss` only
+    // when it returns 0 (success).
+    unsafe {
+        let mut usage: libc::rusage = mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, &mut usage) != 0 {
+            return None;
+        }
+        let maxrss = usage.ru_maxrss.max(0) as u64;
+        // `ru_maxrss` is bytes on Darwin, kilobytes on Linux/BSD.
+        #[cfg(target_os = "macos")]
+        let bytes = maxrss;
+        #[cfg(not(target_os = "macos"))]
+        let bytes = maxrss.saturating_mul(1024);
+        Some(bytes)
+    }
+}
+
+#[cfg(not(unix))]
+fn peak_rss() -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn sample_reports_nonzero_rss_on_unix() {
+        let s = sample();
+        // A live process always has some resident memory; both readers should succeed on the
+        // Unix CI platforms (macOS + Linux).
+        let current = s
+            .current_bytes
+            .expect("current RSS should be readable on unix");
+        assert!(current > 0, "current RSS must be positive, got {current}");
+        let peak = s.peak_bytes.expect("peak RSS should be readable on unix");
+        assert!(
+            peak >= current,
+            "peak RSS ({peak}) should be >= current RSS ({current})"
+        );
+    }
+}

--- a/src/textcompress/checkpoint.rs
+++ b/src/textcompress/checkpoint.rs
@@ -41,7 +41,7 @@ const MAX_FILES: usize = 200;
 /// working-tree change list injected by the caller. The `*_truncated` flags are
 /// set when a list exceeded its cap, so a consumer never mistakes a capped list
 /// for a complete one.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub struct Checkpoint {
     /// Lines that record a decision (see the decision marker set).
     pub decisions: Vec<String>,

--- a/src/textcompress/delta.rs
+++ b/src/textcompress/delta.rs
@@ -38,7 +38,7 @@ const BAIL_MARKER: &str = "# file too large for delta; full content follows";
 /// `output` is the text to surface: the compact diff when `changed && !bailed`,
 /// the `UNCHANGED_MARKER` when `!changed`, or the `BAIL_MARKER` followed by
 /// the NEW content verbatim when `bailed`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, schemars::JsonSchema)]
 pub struct DeltaOutcome {
     /// The text to emit downstream (diff, unchanged marker, or bail + content).
     pub output: String,

--- a/src/textcompress/waste.rs
+++ b/src/textcompress/waste.rs
@@ -63,7 +63,7 @@ pub struct ToolCall {
 }
 
 /// One flagged anti-pattern.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub struct WasteFinding {
     /// Stable detector tag: `redundant_read`, `repeated_query`, or
     /// `oversized_read`.
@@ -77,7 +77,7 @@ pub struct WasteFinding {
 }
 
 /// The full analysis result.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub struct WasteReport {
     /// Deterministically ordered (`kind`, then `target`) findings, capped at
     /// `MAX_FINDINGS`.

--- a/tests/cli_parity.rs
+++ b/tests/cli_parity.rs
@@ -1,0 +1,181 @@
+//! Executable CLI↔MCP parity guard.
+//!
+//! basemind's contract is that every MCP `#[tool]` an agent can call over stdio is ALSO reachable
+//! from the `basemind` CLI (agents and tests drive both). This test makes that contract enforceable:
+//!
+//! 1. It enumerates the live MCP tool surface from the in-process server
+//!    ([`BasemindServer::tool_names`]) — the exact set `tools/list` advertises.
+//! 2. It cross-references that set against `TOOL_TO_CLI`, a maintained table mapping each tool to
+//!    the CLI command that invokes it.
+//! 3. It asserts the mapping is a bijection (every tool mapped, every mapping real) and that each
+//!    mapped CLI path actually resolves (`basemind <path> --help` exits 0).
+//!
+//! A new tool shipped without its CLI counterpart fails step 2 (unmapped tool); a renamed/removed
+//! CLI command fails step 3. The table is feature-gated the same way the routers are, so the guard
+//! is exact under whatever feature set the test is compiled with.
+
+use std::process::Command;
+
+use basemind::cli::context::build_server;
+use basemind::config::DocumentsCliOverrides;
+use basemind::store::VIEW_WORKING;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_basemind")
+}
+
+/// The intended MCP-tool → CLI-command mapping. The CLI value is the argument path (sans the
+/// `basemind` prefix and any positional operands) used to reach the identical tool code. Grouped by
+/// router; feature-gated groups mirror the `#[cfg]` on their `tool_router_*` registration in
+/// `src/mcp/mod.rs` so the set matches `tool_names()` exactly under any feature build.
+fn tool_to_cli() -> Vec<(&'static str, &'static str)> {
+    // `mut` is only exercised when a feature-gated `m.extend(...)` block below is compiled in;
+    // on a default-feature build none of those blocks exist, so `mut` looks unused.
+    #[allow(unused_mut)]
+    let mut m: Vec<(&str, &str)> = vec![
+        // code-map (tool_router_core)
+        ("outline", "query outline"),
+        ("search_symbols", "query search"),
+        ("find_references", "query references"),
+        ("find_callers", "query callers"),
+        ("find_implementations", "query implementations"),
+        ("call_graph", "query call-graph"),
+        ("workspace_grep", "query grep"),
+        ("list_files", "query list-files"),
+        ("dependents", "query dependents"),
+        ("status", "query status"),
+        ("repo_info", "query repo-info"),
+        ("symbol_history", "git symbol-history"),
+        ("rescan", "rescan"),
+        ("telemetry_summary", "telemetry"),
+        // code-aware compression (tool_router_compress)
+        ("expand", "query expand"),
+        ("compress", "compress-output"),
+        ("delta", "delta"),
+        ("checkpoint", "checkpoint"),
+        ("detect_waste", "detect-waste"),
+        // git history (tool_router_git)
+        ("working_tree_status", "git working-tree-status"),
+        ("recent_changes", "git recent-changes"),
+        ("commits_touching", "git commits-touching"),
+        ("find_commits_by_path", "git find-commits-by-path"),
+        ("diff_file", "git diff-file"),
+        ("diff_outline", "git diff-outline"),
+        ("hot_files", "git hot-files"),
+        ("blame_file", "git blame-file"),
+        ("blame_symbol", "git blame-symbol"),
+        ("search_git_history", "git search"),
+        // shared memory (tool_router_memory — shims compile without the feature)
+        ("memory_put", "memory put"),
+        ("memory_get", "memory get"),
+        ("memory_list", "memory list"),
+        ("memory_search", "memory search"),
+        ("memory_delete", "memory delete"),
+        ("search_documents", "memory search-documents"),
+        // governance (tool_router_governance)
+        ("proposals_mine", "governance mine"),
+        ("proposals_list", "governance proposals"),
+        ("proposal_accept", "governance accept"),
+        ("proposal_reject", "governance reject"),
+        ("memory_audit", "governance audit"),
+        // cache admin (tool_router_admin)
+        ("cache_stats", "cache stats"),
+        ("cache_gc", "cache gc"),
+        ("cache_clear", "cache clear"),
+    ];
+    #[cfg(feature = "crawl")]
+    m.extend([
+        ("web_scrape", "web scrape"),
+        ("web_crawl", "web crawl"),
+        ("web_map", "web map"),
+    ]);
+    #[cfg(all(feature = "comms", any(unix, windows)))]
+    m.extend([
+        // Comms CLI verbs connect to the broker directly (a parallel path), but the capability of
+        // every comms tool is reachable from the CLI. `inbox_ack` has no standalone verb — it is
+        // folded into `comms inbox --mark-read`.
+        ("agent_register", "comms register"),
+        ("agent_list", "comms agents"),
+        ("room_create", "comms room-create"),
+        ("room_join", "comms join"),
+        ("room_leave", "comms leave"),
+        ("room_list", "comms rooms"),
+        ("room_post", "comms post"),
+        ("room_history", "comms history"),
+        ("dm_send", "comms dm"),
+        ("inbox_read", "comms inbox"),
+        ("inbox_ack", "comms inbox"),
+        ("message_get", "comms read"),
+        ("get_or_create_chat_room_for_path", "comms room-for-path"),
+    ]);
+    #[cfg(all(feature = "shells", any(unix, windows)))]
+    m.extend([
+        ("shell_spawn", "shells spawn"),
+        ("shell_send", "shells send"),
+        ("shell_capture", "shells capture"),
+        ("shell_kill", "shells kill"),
+        ("shell_broadcast", "shells broadcast"),
+        ("shell_list", "shells list"),
+    ]);
+    m
+}
+
+/// Build a one-shot server over an empty tempdir just to read its advertised tool set. The working
+/// view opens read-only even when never scanned, so no fixture repo is needed.
+fn advertised_tools() -> Vec<String> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let server = build_server(tmp.path(), VIEW_WORKING, DocumentsCliOverrides::default())
+        .expect("build one-shot server");
+    server.tool_names()
+}
+
+#[test]
+fn every_mcp_tool_has_a_cli_command() {
+    let tools = advertised_tools();
+    let map = tool_to_cli();
+    let mapped: std::collections::HashSet<&str> = map.iter().map(|(t, _)| *t).collect();
+
+    // 1. Every advertised MCP tool must be mapped to a CLI command. A new tool without an entry
+    //    here fails — the author must add its CLI counterpart and record the mapping.
+    let unmapped: Vec<&String> = tools
+        .iter()
+        .filter(|t| !mapped.contains(t.as_str()))
+        .collect();
+    assert!(
+        unmapped.is_empty(),
+        "MCP tools with no CLI mapping (add the CLI command + a TOOL_TO_CLI row): {unmapped:?}"
+    );
+
+    // 2. No stale mappings: every mapped tool must still be advertised (catches a renamed/removed
+    //    tool whose stale row would otherwise mask a real gap).
+    let live: std::collections::HashSet<&str> = tools.iter().map(String::as_str).collect();
+    let stale: Vec<&str> = map
+        .iter()
+        .map(|(t, _)| *t)
+        .filter(|t| !live.contains(t))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "TOOL_TO_CLI rows for tools no longer advertised (remove or rename them): {stale:?}"
+    );
+}
+
+#[test]
+fn every_mapped_cli_command_resolves() {
+    // Each mapped CLI path must be a real, wired subcommand: `--help` parses the command tree and
+    // exits 0 without running any tool. A renamed/missing CLI command fails here.
+    for (tool, cli) in tool_to_cli() {
+        let mut args: Vec<&str> = cli.split(' ').collect();
+        args.push("--help");
+        let output = Command::new(bin())
+            .args(&args)
+            .output()
+            .unwrap_or_else(|e| panic!("spawn `basemind {cli} --help`: {e}"));
+        assert!(
+            output.status.success(),
+            "`basemind {cli} --help` (for tool `{tool}`) exited {:?}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -529,6 +529,7 @@ fn cache_stats_reports_blob_accounting() {
             "git_history_bytes",
             "total_bytes",
             "other_bytes",
+            "blob_accounting_ok",
         ],
     );
     assert!(

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -522,11 +522,32 @@ fn cache_stats_reports_blob_accounting() {
     let v = assert_json_fields(
         root,
         &["cache", "stats"],
-        &["blobs_bytes", "blob_count", "orphan_blob_count"],
+        &[
+            "blobs_bytes",
+            "blob_count",
+            "orphan_blob_count",
+            "git_history_bytes",
+            "total_bytes",
+            "other_bytes",
+        ],
     );
     assert!(
         v["blob_count"].as_u64().unwrap() >= 2,
         "at least one blob per file"
+    );
+    // The CLI shares `store_gc::cache_stats` with the MCP tool, so it reports the same
+    // reconciling total (components + other == total) that the MCP smoke test asserts.
+    let u = |k: &str| v[k].as_u64().unwrap_or_default();
+    let component_sum = u("blobs_bytes")
+        + u("views_bytes")
+        + u("lance_bytes")
+        + u("git_cache_bytes")
+        + u("telemetry_bytes")
+        + u("git_history_bytes");
+    assert_eq!(
+        u("total_bytes"),
+        component_sum + u("other_bytes"),
+        "total_bytes must reconcile to components + other"
     );
     assert_human_contains(root, &["cache", "stats"], "blob_count");
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -188,6 +188,26 @@ fn git_working_tree_status_is_clean() {
 }
 
 #[test]
+fn git_search_finds_commit_by_author() {
+    let dir = build_and_scan();
+    let root = dir.path();
+    // The fixture's single commit is authored by "t" (see `git()` env). Full-text author search
+    // over the indexed history must return it — the CLI mirror of the `search_git_history` tool.
+    let v = assert_json_fields(
+        root,
+        &["git", "search", "t", "--field", "author"],
+        &["commits"],
+    );
+    let commits = v["commits"].as_array().expect("commits array");
+    assert_eq!(commits.len(), 1, "author search should find the one commit");
+    assert_human_contains(
+        root,
+        &["git", "search", "init", "--field", "message"],
+        "init",
+    );
+}
+
+#[test]
 fn rescan_full_reindexes_new_file() {
     let dir = build_and_scan();
     let root = dir.path();

--- a/tests/git_history_smoke.rs
+++ b/tests/git_history_smoke.rs
@@ -485,3 +485,98 @@ fn empty_index_before_sync_falls_back() {
     assert!(index.is_empty());
     assert_eq!(index.last_indexed_head_hex(), None);
 }
+
+/// Commit authored by `name`/`email` at an explicit ISO date, so the newest-first walk order is
+/// unambiguous even across many commits (the shared `commit_authored` pins a single timestamp,
+/// which leaves same-second ordering to the traversal — fine for a handful of commits, not for the
+/// deep history this test builds).
+fn commit_authored_at(
+    root: &Path,
+    path: &str,
+    content: &str,
+    name: &str,
+    email: &str,
+    subject: &str,
+    date: &str,
+) {
+    fs::write(root.join(path), content).unwrap();
+    run(root, &["add", path]);
+    let status = Command::new("git")
+        .args(["commit", "-q", "-m", subject])
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", name)
+        .env("GIT_AUTHOR_EMAIL", email)
+        .env("GIT_COMMITTER_NAME", name)
+        .env("GIT_COMMITTER_EMAIL", email)
+        .env("GIT_AUTHOR_DATE", date)
+        .env("GIT_COMMITTER_DATE", date)
+        .status()
+        .expect("git in PATH");
+    assert!(status.success(), "git commit failed");
+}
+
+/// Regression for the reported precision bug: an author whose latest commit is buried deeper than
+/// the `recent_changes` window (limit ≤ 100). `search_git_history(field=author)` must still find it
+/// — matching `git log -i --author` at full branch depth — while the newest-100 window does not
+/// contain it, which is exactly why routing an author question to `recent_changes` returned "no
+/// commit by that author". Branch/HEAD-scoped throughout (no `--all`).
+#[test]
+fn author_search_finds_commit_beyond_recent_window_matches_git() {
+    let dir = init_repo();
+    let root = dir.path();
+
+    // Oldest commit (rank 121): the author we later look for.
+    commit_authored_at(
+        root,
+        "a.rs",
+        "fn a() {}\n",
+        "Dor Green",
+        "dor@example.com",
+        "early: seed the module",
+        "2025-01-01T00:00:00",
+    );
+    // Bury it under 120 strictly-later commits by a different author.
+    for i in 0..120 {
+        let date = format!("2025-01-01T{:02}:{:02}:00", 1 + (i / 60), i % 60);
+        commit_authored_at(
+            root,
+            "b.rs",
+            &format!("v{i}\n"),
+            "Other Dev",
+            "other@example.com",
+            &format!("chore: change {i}"),
+            &date,
+        );
+    }
+
+    let (index, _) = sync(root);
+    assert_eq!(index.commit_count(), 121);
+
+    // Oracle: git's own HEAD-scoped, case-insensitive author search, newest first.
+    let git_newest = capture(
+        root,
+        &["log", "-i", "--author=Dor Green", "--format=%H", "-1"],
+    )
+    .trim()
+    .to_string();
+    assert!(!git_newest.is_empty(), "git finds Dor Green's commit");
+
+    // search_git_history(author) returns exactly Dor's commit — full-depth, matching git.
+    assert_eq!(
+        search_shas(&index, "Dor Green", FtsScope::Author),
+        vec![git_newest.clone()],
+        "author search matches `git log -i --author` at full depth"
+    );
+
+    // And it lives beyond the newest-100 window that `recent_changes` scans — the bug's root cause.
+    let recent: Vec<String> = index
+        .recent_commits(0, 100, false)
+        .into_iter()
+        .map(|c| c.sha)
+        .collect();
+    assert_eq!(recent.len(), 100, "the recent window is capped at 100");
+    assert!(
+        !recent.contains(&git_newest),
+        "Dor's commit is outside the newest-100 window, so a recent-window scan misses it"
+    );
+}

--- a/tests/git_parity.rs
+++ b/tests/git_parity.rs
@@ -1,0 +1,190 @@
+//! Precision parity of the git-history index against **real git**, on a real repository, at full
+//! branch depth. The deterministic synthetic cases live in `git_history_smoke.rs`; this harness
+//! points at a large real repo to catch precision bugs that only surface at scale (deep author
+//! history, thousands of commits, real tokenization).
+//!
+//! `#[ignore]`-gated like `harden.rs` — run explicitly:
+//!
+//! ```bash
+//! BASEMIND_GIT_PARITY_REPO=/abs/path/to/repo \
+//!   cargo test --release --test git_parity -- --ignored --nocapture
+//! ```
+//!
+//! With no `BASEMIND_GIT_PARITY_REPO` set the test skips (prints a note) so it stays a no-op in
+//! environments without a target repo. The target repo is referenced **only** through this env var
+//! — never hardcoded — so no specific repository name lives in the tree.
+//!
+//! Every git oracle is pinned to the exact sha the index built from (`last_indexed_head_hex`), not
+//! live `HEAD` — the target may be an actively-committed working repo, and the index build takes a
+//! minute-plus, so an unpinned `git log HEAD` would race new commits and diverge spuriously.
+//!
+//! Scope: HEAD/current-branch, matching plain `git log <sha>` (NOT `git log --all`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use basemind::git::Repo;
+use basemind::git_history::GitHistoryIndex;
+use basemind::git_history::builder;
+use basemind::git_history::fts::FtsScope;
+
+/// `git -C <repo> <args>` → trimmed stdout lines (drops the trailing empty line).
+fn git_lines(repo: &Path, args: &[&str]) -> Vec<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git in PATH");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .expect("utf8")
+        .lines()
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn git_one(repo: &Path, args: &[&str]) -> Option<String> {
+    git_lines(repo, args).into_iter().next()
+}
+
+/// The repo under test, or `None` to skip.
+fn target_repo() -> Option<PathBuf> {
+    let raw = std::env::var("BASEMIND_GIT_PARITY_REPO").ok()?;
+    let path = PathBuf::from(raw);
+    assert!(
+        path.join(".git").exists(),
+        "BASEMIND_GIT_PARITY_REPO={} is not a git repo (no .git)",
+        path.display()
+    );
+    Some(path)
+}
+
+/// Build a fresh git-history index for `repo` in a throwaway `.basemind/` (never touches the repo's
+/// real cache), synced to HEAD, and return it with the exact sha it indexed. All git oracles use
+/// that sha so a commit landing mid-build can't race the comparison.
+fn build_index(repo: &Path, scratch: &Path) -> (GitHistoryIndex, String) {
+    let repository = Repo::discover(repo).expect("discover repo");
+    let index = GitHistoryIndex::open(scratch).expect("open git-history index");
+    let outcome = builder::sync(&index, &repository, scratch).expect("sync git-history index");
+    let head = index
+        .last_indexed_head_hex()
+        .expect("index records the head it built from");
+    eprintln!(
+        "git_parity: built index — {outcome:?}, {} commits, head {}",
+        index.commit_count(),
+        &head[..12.min(head.len())]
+    );
+    (index, head)
+}
+
+#[test]
+#[ignore = "requires BASEMIND_GIT_PARITY_REPO to point at a real repo"]
+fn author_search_matches_real_git_at_full_depth() {
+    let Some(repo) = target_repo() else {
+        eprintln!("git_parity: BASEMIND_GIT_PARITY_REPO unset — skipping");
+        return;
+    };
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let (index, head) = build_index(&repo, scratch.path());
+
+    // Pick a real author deep in history: the author of the 250th commit back (well outside any
+    // recent window). Falls back to the tip's author on a shallow repo. Pinned to the index head.
+    let deep = git_one(&repo, &["log", &head, "--format=%an", "-1", "--skip=250"])
+        .or_else(|| git_one(&repo, &["log", &head, "--format=%an", "-1"]))
+        .expect("at least one commit");
+    eprintln!("git_parity: author under test = {deep:?}");
+
+    // Oracle: git's own case-insensitive author search over the pinned head's history.
+    let git_shas = git_lines(
+        &repo,
+        &[
+            "log",
+            &head,
+            "-i",
+            &format!("--author={deep}"),
+            "--format=%H",
+        ],
+    );
+    assert!(!git_shas.is_empty(), "git found no commits for {deep:?}");
+    let git_newest = &git_shas[0];
+    let git_set: std::collections::HashSet<&String> = git_shas.iter().collect();
+
+    // Index: full-depth author search, newest-first.
+    let hits = index.search_commits(&deep, FtsScope::Author, 0, 5000);
+    assert!(
+        !hits.is_empty(),
+        "index author search returned nothing for {deep:?} (git found {})",
+        git_shas.len()
+    );
+
+    // 1. The newest hit is the author's most recent commit — the "what did <author> do last" answer.
+    assert_eq!(
+        &hits[0].sha, git_newest,
+        "index newest author commit must equal `git log -i --author` newest"
+    );
+
+    // 2. No false positives: every indexed hit is a real reachable commit by that author.
+    //    (git's `--author` is a substring/regex match; token-AND is a subset of it, so ⊆ must hold.)
+    for h in &hits {
+        assert!(
+            git_set.contains(&h.sha),
+            "indexed author hit {} is not in git's author set for {deep:?}",
+            h.sha
+        );
+    }
+    eprintln!(
+        "git_parity: author {deep:?} — git {} commits, index returned {} (newest matches)",
+        git_shas.len(),
+        hits.len()
+    );
+}
+
+#[test]
+#[ignore = "requires BASEMIND_GIT_PARITY_REPO to point at a real repo"]
+fn recent_and_path_history_match_real_git() {
+    let Some(repo) = target_repo() else {
+        eprintln!("git_parity: BASEMIND_GIT_PARITY_REPO unset — skipping");
+        return;
+    };
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let (index, head) = build_index(&repo, scratch.path());
+
+    // recent_changes parity: newest 50 commits, newest-first, pinned to the index head.
+    let git_recent = git_lines(&repo, &["log", &head, "--format=%H", "-50"]);
+    let idx_recent: Vec<String> = index
+        .recent_commits(0, git_recent.len(), false)
+        .into_iter()
+        .map(|c| c.sha)
+        .collect();
+    assert_eq!(
+        idx_recent, git_recent,
+        "recent_commits must match `git log <head>` newest-first, exactly"
+    );
+
+    // commits_touching parity for a real tracked path: use a file changed in the head commit.
+    if let Some(path) = git_one(&repo, &["show", "--format=", "--name-only", &head]) {
+        let git_touch = git_lines(
+            &repo,
+            &["log", &head, "--full-history", "--format=%H", "--", &path],
+        );
+        let idx_touch: Vec<String> = index
+            .commits_touching(&path.as_bytes().into(), 0, git_touch.len())
+            .into_iter()
+            .map(|c| c.sha)
+            .collect();
+        assert_eq!(
+            idx_touch, git_touch,
+            "commits_touching({path}) must match `git log --full-history -- <path>`"
+        );
+        eprintln!(
+            "git_parity: commits_touching({path}) — {} commits match",
+            git_touch.len()
+        );
+    }
+}

--- a/tests/harden.rs
+++ b/tests/harden.rs
@@ -659,6 +659,32 @@ fn assert_passing(
         if m.commits == 0 {
             failures.push("git-history index built zero commits".to_string());
         }
+        // Resource-stats canary: a built git-history index must be counted by cache_stats
+        // (`git_history_bytes > 0`) and rolled into the total — the WS1 fix for the reported
+        // disk-footprint undercount. Only asserted when the stats canary was captured.
+        if m.commits > 0
+            && let Some(gh) = repo_record
+                .canaries
+                .get("stats_git_history_bytes")
+                .and_then(Value::as_u64)
+        {
+            if gh == 0 {
+                failures.push(format!(
+                    "cache_stats: git_history_bytes is 0 despite a built git-history index ({} commits) — the index is uncounted",
+                    m.commits
+                ));
+            }
+            if let Some(total) = repo_record
+                .canaries
+                .get("stats_total_bytes")
+                .and_then(Value::as_u64)
+                && total < gh
+            {
+                failures.push(format!(
+                    "cache_stats: total_bytes ({total}) < git_history_bytes ({gh}) — git-history not rolled into the total"
+                ));
+            }
+        }
         if let Some(ct) = m
             .queries
             .iter()
@@ -790,6 +816,36 @@ fn assert_passing(
                     "django canary: commits_touching(\"django/db/models/query.py\") returned {query_commits} commits (expected ≥ 10)"
                 ));
             }
+            // Author-parity canary (anti-regression for the reported "author's commits missing"
+            // bug): full-depth author search must find the deep-history author sampled from real
+            // git, and must not leak commits by other authors into the author scope. Only asserted
+            // when the sample was taken (canary present).
+            if let Some(author_hits) = repo_record
+                .canaries
+                .get("author_search_hits")
+                .and_then(Value::as_u64)
+            {
+                if author_hits < 1 {
+                    let token = repo_record
+                        .canaries
+                        .get("author_search_token")
+                        .and_then(Value::as_str)
+                        .unwrap_or("?");
+                    failures.push(format!(
+                        "django canary: search_git_history(author={token:?}) found 0 commits for a deep-history author — full-depth author search regressed"
+                    ));
+                }
+                if repo_record
+                    .canaries
+                    .get("author_search_consistent")
+                    .and_then(Value::as_bool)
+                    == Some(false)
+                {
+                    failures.push(
+                        "django canary: search_git_history(field=author) returned a commit whose author does not match the query — author scope leaked".into(),
+                    );
+                }
+            }
             // Governance canary — enforced only when mining actually ran (the `proposals_mined`
             // value is present, i.e. the harness was built with `--features memory`). Django
             // yields several co-change candidates at the default thresholds; ≥ 1 is a
@@ -811,9 +867,54 @@ fn assert_passing(
     failures
 }
 
-async fn capture_canaries(svc: &ServiceHandle, repo_name: &str, record: &mut RepoRecord) {
+/// Run `git -C <repo> <args>` and return the first non-blank stdout line, trimmed. `None` on any
+/// failure or empty output. Used by canaries that need a real-git oracle (e.g. sampling a
+/// deep-history author). Best-effort: a canary that can't derive its input is simply not recorded,
+/// so a git hiccup never turns into a spurious failure.
+fn git_first_line(repo: &Path, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout)
+        .ok()?
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())
+}
+
+async fn capture_canaries(
+    svc: &ServiceHandle,
+    repo_name: &str,
+    repo_root: &Path,
+    record: &mut RepoRecord,
+) {
     // Always evaluate canaries on a best-effort basis — failures here don't block
     // the rest of the suite. We feed the results back into assert_passing.
+
+    // Global (every repo): resource-stats canary. `cache_stats` must count the git-history index in
+    // its per-component breakdown — the reported "1.15 GB reported vs 1.5 GB on disk" gap was the
+    // uncounted `git-history.fjall/` — and roll every component into `total_bytes`. Asserted in
+    // `assert_passing` only where the git-history index actually built (`commits > 0`).
+    if let Ok(out) = svc.call_tool(call_params("cache_stats", &json!({}))).await {
+        let body = decode_text(&out);
+        if let Some(gh) = body.get("git_history_bytes").and_then(Value::as_u64) {
+            record
+                .canaries
+                .insert("stats_git_history_bytes".into(), json!(gh));
+        }
+        if let Some(total) = body.get("total_bytes").and_then(Value::as_u64) {
+            record
+                .canaries
+                .insert("stats_total_bytes".into(), json!(total));
+        }
+    }
+
     match repo_name {
         "react" => {
             let res = svc
@@ -989,6 +1090,54 @@ async fn capture_canaries(svc: &ServiceHandle, repo_name: &str, record: &mut Rep
                 record
                     .canaries
                     .insert("search_fixed_commits".into(), json!(hits));
+            }
+            // Author-parity canary (the reported bug): sample an author deep in history (skip 500,
+            // far outside any recent window), then prove full-depth `search_git_history` by author
+            // finds them. Self-consistent: every returned hit's author name/email must contain the
+            // queried token — the FTS must not leak commits by other authors into an author scope.
+            // Derived from real git so it self-adapts across django releases; skipped if the sample
+            // can't be taken (canary simply absent, never a spurious fail).
+            if let Some(author) =
+                git_first_line(repo_root, &["log", "--format=%an", "-1", "--skip=500"])
+                && let Some(token) = author
+                    .split_whitespace()
+                    .find(|w| w.chars().all(char::is_alphabetic) && w.len() >= 3)
+                && let Ok(out) = svc
+                    .call_tool(call_params(
+                        "search_git_history",
+                        &json!({ "pattern": token, "field": "author", "limit": 100 }),
+                    ))
+                    .await
+            {
+                let body = decode_text(&out);
+                let commits = body
+                    .get("commits")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                let token_lc = token.to_lowercase();
+                let consistent = commits.iter().all(|c| {
+                    let name = c
+                        .get("author")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_lowercase();
+                    let email = c
+                        .get("author_email")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_lowercase();
+                    name.contains(&token_lc) || email.contains(&token_lc)
+                });
+                record
+                    .canaries
+                    .insert("author_search_hits".into(), json!(commits.len() as u64));
+                record
+                    .canaries
+                    .insert("author_search_consistent".into(), json!(consistent));
+                record
+                    .canaries
+                    .insert("author_search_token".into(), json!(token));
             }
             // Governance canary — only populated under `--features memory`; with the feature
             // off, `proposals_mine` returns an MCP error and the canary stays absent (so the
@@ -1370,7 +1519,7 @@ async fn harden_repo() {
     }
 
     // 4. Per-repo canary captures (read-only; results go into record.canaries).
-    capture_canaries(&svc, &repo_name, &mut record).await;
+    capture_canaries(&svc, &repo_name, &repo, &mut record).await;
 
     // 5. Persist the per-repo record before assertions so we get partial data
     //    even when a later step panics.

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1656,6 +1656,41 @@ async fn mcp_server_exercises_representative_tools() {
         "the working view should be listed: {body}"
     );
 
+    // 0.16 resource-footprint fields: the ground-truth total must reconcile exactly to the sum of
+    // the named components plus the unattributed remainder (so no directory can go uncounted), and
+    // the git-history index (`git-history.fjall/`) — omitted before 0.16 — is now part of it.
+    let u = |k: &str| body.get(k).and_then(Value::as_u64).unwrap_or_default();
+    let total = u("total_bytes");
+    let component_sum = u("blobs_bytes")
+        + u("views_bytes")
+        + u("lance_bytes")
+        + u("git_cache_bytes")
+        + u("telemetry_bytes")
+        + u("git_history_bytes");
+    assert_eq!(
+        total,
+        component_sum + u("other_bytes"),
+        "total_bytes must reconcile to components + other: {body}"
+    );
+    assert!(
+        total >= component_sum,
+        "total_bytes must be at least the component sum: {body}"
+    );
+    assert!(
+        body.get("git_history_bytes")
+            .and_then(Value::as_u64)
+            .is_some(),
+        "git_history_bytes field must be present: {body}"
+    );
+    // RSS is best-effort per platform; when present it must be a positive number (the MCP server
+    // process is alive while answering).
+    if let Some(rss) = body.get("rss_bytes").and_then(Value::as_u64) {
+        assert!(
+            rss > 0,
+            "rss_bytes, when reported, is the live server RSS: {body}"
+        );
+    }
+
     // cache_gc: nothing is orphaned right after a scan, so removed == 0 and bytes_freed == 0.
     let body = decode_text(
         &service

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -2214,6 +2214,148 @@ async fn mcp_server_exercises_representative_tools() {
         "expand via `symbol` alias must resolve correctly: {body}"
     );
 
+    // delta: a stateless line-diff between two inline strings. `old` -> `new` swaps one line
+    // and appends another: 1 delete + 2 adds.
+    let body = decode_text(
+        &service
+            .call_tool(call_params(
+                "delta",
+                json!({
+                    "old": "alpha\nbeta\ngamma\n",
+                    "new": "alpha\nbeta2\ngamma\ndelta\n",
+                }),
+            ))
+            .await
+            .expect("delta(old, new)"),
+    );
+    assert_eq!(
+        body.get("changed").and_then(Value::as_bool),
+        Some(true),
+        "differing inputs must report changed=true: {body}"
+    );
+    assert_eq!(
+        body.get("bailed").and_then(Value::as_bool),
+        Some(false),
+        "small inputs must not bail: {body}"
+    );
+    assert_eq!(
+        body.get("added").and_then(Value::as_u64),
+        Some(2),
+        "beta2 + delta are the two adds: {body}"
+    );
+    assert_eq!(
+        body.get("removed").and_then(Value::as_u64),
+        Some(1),
+        "beta is the single deletion: {body}"
+    );
+    let delta_output = body.get("output").and_then(Value::as_str).expect("output");
+    assert!(
+        delta_output.starts_with("+2/-1"),
+        "delta output must lead with the +A/-R header: {delta_output:?}"
+    );
+
+    // delta: identical inputs must report unchanged.
+    let body = decode_text(
+        &service
+            .call_tool(call_params(
+                "delta",
+                json!({ "old": "same\n", "new": "same\n" }),
+            ))
+            .await
+            .expect("delta(identical)"),
+    );
+    assert_eq!(
+        body.get("changed").and_then(Value::as_bool),
+        Some(false),
+        "identical inputs must report changed=false: {body}"
+    );
+
+    // checkpoint: session text with a decision line + an untracked file in the working tree.
+    // `files_changed` must come from git status, not be scraped from `text`.
+    std::fs::write(root.join("checkpoint_probe.txt"), b"probe\n").unwrap();
+    let body = decode_text(
+        &service
+            .call_tool(call_params(
+                "checkpoint",
+                json!({ "text": "We decided to use rayon.\nerror: build failed\n" }),
+            ))
+            .await
+            .expect("checkpoint(text)"),
+    );
+    assert_eq!(
+        body.get("decisions").and_then(Value::as_array),
+        Some(&vec![Value::String("We decided to use rayon.".to_string())]),
+        "checkpoint must extract the decision line: {body}"
+    );
+    assert_eq!(
+        body.get("errors").and_then(Value::as_array),
+        Some(&vec![Value::String("error: build failed".to_string())]),
+        "checkpoint must extract the error line: {body}"
+    );
+    let files_changed: Vec<&str> = body
+        .get("files_changed")
+        .and_then(Value::as_array)
+        .expect("files_changed")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        files_changed.contains(&"checkpoint_probe.txt"),
+        "files_changed must come from this repo's git working tree: {files_changed:?}"
+    );
+
+    // detect_waste: two JSON-Lines reads of the same target must fire redundant_read with the
+    // exact count + waste accounting.
+    let log = "{\"tool\":\"Read\",\"target\":\"a.rs\",\"bytes\":100}\n\
+               {\"tool\":\"Read\",\"target\":\"a.rs\",\"bytes\":100}\n";
+    let body = decode_text(
+        &service
+            .call_tool(call_params("detect_waste", json!({ "log": log })))
+            .await
+            .expect("detect_waste(log)"),
+    );
+    let findings = body
+        .get("findings")
+        .and_then(Value::as_array)
+        .expect("findings");
+    assert_eq!(
+        findings.len(),
+        1,
+        "two redundant reads of one target must yield exactly one finding: {body}"
+    );
+    let finding = &findings[0];
+    assert_eq!(
+        finding.get("kind").and_then(Value::as_str),
+        Some("redundant_read"),
+        "finding kind: {finding}"
+    );
+    assert_eq!(
+        finding.get("target").and_then(Value::as_str),
+        Some("a.rs"),
+        "finding target: {finding}"
+    );
+    assert_eq!(
+        finding.get("count").and_then(Value::as_u64),
+        Some(2),
+        "finding count: {finding}"
+    );
+    assert_eq!(
+        finding.get("estimated_waste_bytes").and_then(Value::as_u64),
+        Some(100),
+        "waste is the bytes of every read after the first: {finding}"
+    );
+    assert_eq!(
+        body.get("total_estimated_waste_bytes")
+            .and_then(Value::as_u64),
+        Some(100),
+        "total_estimated_waste_bytes: {body}"
+    );
+    assert_eq!(
+        body.get("truncated").and_then(Value::as_bool),
+        Some(false),
+        "well under MAX_FINDINGS must not truncate: {body}"
+    );
+
     let _ = service.cancel().await;
 }
 

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -188,6 +188,12 @@ async fn mcp_server_exercises_representative_tools() {
     );
     let file_count = body.get("file_count").and_then(Value::as_u64).unwrap_or(0);
     assert!(file_count >= 2, "scan should have indexed at least 2 files");
+    // On the uncontended path `status` reads the committed index (no rebuild in flight), so the
+    // WS4 `rebuild_in_progress` flag is omitted (skipped when false).
+    assert!(
+        body.get("rebuild_in_progress").is_none(),
+        "rebuild_in_progress must be absent when no writer holds the lock: {body:?}"
+    );
     let langs = body
         .get("languages")
         .and_then(Value::as_object)

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -1682,6 +1682,12 @@ async fn mcp_server_exercises_representative_tools() {
             .is_some(),
         "git_history_bytes field must be present: {body}"
     );
+    // A freshly-scanned fixture has a readable index, so orphan accounting ran.
+    assert_eq!(
+        body.get("blob_accounting_ok").and_then(Value::as_bool),
+        Some(true),
+        "blob_accounting_ok must be true on a clean scan: {body}"
+    );
     // RSS is best-effort per platform; when present it must be a positive number (the MCP server
     // process is alive while answering).
     if let Some(rss) = body.get("rss_bytes").and_then(Value::as_u64) {

--- a/tests/serve_contention_smoke.rs
+++ b/tests/serve_contention_smoke.rs
@@ -10,6 +10,7 @@
 //!   still answers reads, instead of exiting and handing the MCP client an opaque `-32000`.
 
 use std::fs;
+use std::process::Command;
 use std::time::{Duration, Instant};
 
 use basemind::config::ConfigV1;
@@ -80,4 +81,44 @@ fn read_only_serve_coexists_with_live_writer() {
         "read-only serve must resolve symbols from the shared index"
     );
     assert_eq!(hits[0].path.as_str(), Some("a.rs"));
+}
+
+#[test]
+fn cli_scan_exits_cleanly_when_a_writer_holds_the_lock() {
+    // Double-run UX (report): an editor plugin's `basemind serve` holds the write lock while the
+    // user (or another plugin command) runs `basemind scan` directly. The pre-flight probe must
+    // detect the live holder, print actionable guidance naming it, and exit 0 — never collide with
+    // a raw lock error or busy-wait.
+    let dir = scanned_repo();
+    let root = dir.path();
+    let _writer =
+        Store::open_with_holder(root, VIEW_WORKING, LockHolder::Serve).expect("writer holds lock");
+
+    let started = Instant::now();
+    let output = Command::new(env!("CARGO_BIN_EXE_basemind"))
+        .args(["scan"])
+        .current_dir(root)
+        .output()
+        .expect("run basemind scan");
+    let elapsed = started.elapsed();
+
+    assert!(
+        output.status.success(),
+        "scan against a held lock must exit cleanly (0), got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("basemind serve") && combined.contains("rescan"),
+        "notice must name the `basemind serve` holder and point at its `rescan` tool, got:\n{combined}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "pre-flight scan took {elapsed:?} — should short-circuit, not block on lock retries"
+    );
 }


### PR DESCRIPTION
Hardening pass driven by the first real-world bug report (a large private monorepo). Closes the reported disk-stats gap, adds RAM reporting, proves git precision against real `git`, completes CLI↔MCP parity, and fixes two lock/latency UX papercuts. No version bump (not shipping from here).

## Resource stats (disk + RAM)
- `cache_stats` / `basemind cache stats` now report a `total_bytes` that reconciles with `du` exactly, a per-component breakdown that **includes `git-history.fjall/`** (the "1.15 GB reported vs 1.5 GB on disk" gap — it was never counted), an `other_bytes` catch-all, and process RAM (`rss_bytes` + `peak_rss_bytes`) via a new cross-platform `src/sysres.rs`. Disk sizing uses on-disk block counts, so Fjall's sparse journals stop over-reporting.
- `cache_stats` degrades on a stale/unreadable index (`blob_accounting_ok: false`) instead of hard-failing.
- Statusline + `/bm-stats` gain the footprint; `/bm-stats` is now CLI-first (works with the server disconnected).

## Git precision
- The "no commit by <author>" report was a **routing** bug: author/keyword questions went to the 100-cap `recent_changes` instead of the full-depth `search_git_history`. Sharpened both tool descriptions.
- New `tests/git_parity.rs` proves parity vs real `git` at full branch depth (opt-in via `BASEMIND_GIT_PARITY_REPO`); verified against a 243k-commit repo (author 328/328 exact, recent/path exact).

## CLI↔MCP full parity
- New CLI: `git search`, `governance audit`, `query expand`, and a `shells` group (`--features shells`).
- New MCP tools for the CLI-only text primitives: `delta`, `checkpoint`, `detect_waste`.
- `tests/cli_parity.rs` enumerates the advertised MCP tool set and fails if any tool lacks a CLI counterpart.

## UX robustness
- `scan`/`rescan` pre-detect a live `serve`/`watch` holding the lock and exit cleanly with an actionable notice (the double-run case) instead of a raw lock error.
- `status` uses a non-blocking read, so a multi-minute rebuild is no longer recorded as the call's wall-clock (the misleading 1424280ms); it returns `rebuild_in_progress: true` immediately.

## Housekeeping
- Extracted lock machinery to `src/store_lock.rs` to keep `store.rs` under the 1000-line module cap.

Full suite green (310 lib + integration). No `armis` string anywhere in the tree — the private repo is referenced only via env var.
